### PR TITLE
森林能量雨优化

### DIFF
--- a/app/src/main/java/io/github/aoguai/sesameag/data/StatusFlags.kt
+++ b/app/src/main/java/io/github/aoguai/sesameag/data/StatusFlags.kt
@@ -154,5 +154,15 @@ object StatusFlags {
 
     /** 庄园家庭：今日好友分享已处理 */
     const val FLAG_FARM_FAMILY_SHARE_TO_FRIENDS = "antFarm::familyShareToFriends"
+
+    /** 森林：能量雨机会卡今日已使用 */
+    const val FLAG_FOREST_RAIN_CHANCE_CARD = "AntForest::useEnergyRainChanceCard"
+
+    /** 森林：能量雨赠送已达到今日上限标记 */
+    const val FLAG_FOREST_RAIN_GRANT_EXCEED = "AntForest::grantEnergyRainExceed"
+
+    /** 森林：能量雨附加游戏任务标记 */
+    const val FLAG_FOREST_RAIN_GAME_TASK = "AntForest::EnergyRainGameTask"
+
 }
 

--- a/app/src/main/java/io/github/aoguai/sesameag/task/antForest/AntForest.kt
+++ b/app/src/main/java/io/github/aoguai/sesameag/task/antForest/AntForest.kt
@@ -5387,57 +5387,22 @@ class AntForest : ModelTask(), EnergyCollectCallback {
 
     internal suspend fun useEnergyRainChanceCard() {
         try {
-            suspend fun hasPlayableEnergyRainChance(): Boolean {
-                return try {
-                    val jo = JSONObject(AntForestRpcCall.queryEnergyRainHome())
-                    ResChecker.checkRes(TAG, jo) && jo.optBoolean("canPlayToday", false)
-                } catch (t: Throwable) {
-                    Log.printStackTrace(TAG, "queryEnergyRainHome err", t)
-                    false
-                }
-            }
-
-            fun getLimitTimeEnergyRainFlag(propJsonObj: JSONObject): String? {
-                val propId = propJsonObj.optJSONArray("propIdList")?.optString(0).orEmpty()
-                if (propId.isEmpty()) {
-                    return null
-                }
-                return "AntForest::useEnergyRainChanceCard::LIMIT_TIME_ENERGY_RAIN_CHANCE::$propId"
-            }
-
-            if (hasPlayableEnergyRainChance()) {
-                Log.forest(TAG, "当前已有可执行的能量雨机会，跳过重复激活")
+            if (Status.hasFlagToday(StatusFlags.FLAG_FOREST_RAIN_CHANCE_CARD)) {
                 return
             }
-
-            var usedAny = false
             val propTypes = arrayOf("LIMIT_TIME_ENERGY_RAIN_CHANCE", "ENERGY_RAIN_CHANCE")
             for (propType in propTypes) {
-                while (!Thread.currentThread().isInterrupted) {
+                while (true) {
                     val jo = findPropBag(queryPropList(true), propType) ?: break
-                    if (propType == "LIMIT_TIME_ENERGY_RAIN_CHANCE") {
-                        val todayFlag = getLimitTimeEnergyRainFlag(jo)
-                        if (todayFlag != null && Status.hasFlagToday(todayFlag)) {
-                            Log.forest(TAG, "限时能量雨机会今日已激活，跳过重复使用")
-                            break
-                        }
-                    }
                     if (usePropBag(jo)) {
                         Log.forest(TAG, "成功使用一个能量雨道具: $propType")
-                        usedAny = true
-                        if (propType == "LIMIT_TIME_ENERGY_RAIN_CHANCE") {
-                            getLimitTimeEnergyRainFlag(jo)?.let { Status.setFlagToday(it) }
-                        }
-                        ActionDelayUtil.humanActionDelay(2000L)
-                        if (propType == "LIMIT_TIME_ENERGY_RAIN_CHANCE") {
-                            break
-                        }
+                        delay(2000)
                     } else {
                         break
                     }
                 }
 
-                if (propType == "LIMIT_TIME_ENERGY_RAIN_CHANCE" && !hasPlayableEnergyRainChance()) {
+                if (propType == "LIMIT_TIME_ENERGY_RAIN_CHANCE") {
                     val skuInfo = Vitality.findSkuInfoBySkuName("能量雨次卡")
                     if (skuInfo != null) {
                         val skuId = skuInfo.getString("skuId")
@@ -5448,21 +5413,17 @@ class AntForest : ModelTask(), EnergyCollectCallback {
                                     "限时能量雨机会"
                                 )
                             ) {
-                                ActionDelayUtil.humanActionDelay(1000L)
+                                delay(1000)
                                 val joExchanged = findPropBag(queryPropList(true), propType)
                                 if (joExchanged != null && usePropBag(joExchanged)) {
-                                    getLimitTimeEnergyRainFlag(joExchanged)?.let { Status.setFlagToday(it) }
-                                    usedAny = true
-                                    ActionDelayUtil.humanActionDelay(1000L)
+                                    delay(1000)
                                 }
                             }
                         }
                     }
                 }
             }
-            if (!usedAny) {
-                Log.forest(TAG, "当前无可激活的能量雨道具")
-            }
+            Status.setFlagToday(StatusFlags.FLAG_FOREST_RAIN_CHANCE_CARD)
             Log.forest(TAG, "所有能量雨卡已处理完毕")
         } catch (e: CancellationException) {
             throw e
@@ -6278,7 +6239,7 @@ class AntForest : ModelTask(), EnergyCollectCallback {
                     useEnergyRainChanceCard()
                 }
 
-                EnergyRainCoroutine.execEnergyRainCompat()
+                EnergyRainCoroutine.execEnergyRain(isManual = true)
                 Log.forest(TAG, "✅ 手动能量雨任务处理完毕")
             } else {
                 Log.forest(TAG, "无法获取自己主页信息")

--- a/app/src/main/java/io/github/aoguai/sesameag/task/antForest/AntForestRpcCall.kt
+++ b/app/src/main/java/io/github/aoguai/sesameag/task/antForest/AntForestRpcCall.kt
@@ -1181,5 +1181,18 @@ object AntForestRpcCall {
             JSONArray().put(jo).toString()
         )
     }
+
+    /** 模拟点击进入游戏 */
+    @JvmStatic
+    fun clickGame(appId: String): String {
+        return RequestManager.requestString("com.alipay.charitygamecenter.clickGame",
+            "[{" +
+                    "  \"appId\": \"$appId\"," +
+                    "  \"bizType\": \"ANTFOREST\"," +
+                    "  \"requestType\": \"RPC\"," +
+                    "  \"sceneCode\": \"ANTFOREST\"," +
+                    "  \"source\": \"ANTFOREST\"" +
+                    "}]")
+    }
 }
 

--- a/app/src/main/java/io/github/aoguai/sesameag/task/antForest/AntForestWorkflow.kt
+++ b/app/src/main/java/io/github/aoguai/sesameag/task/antForest/AntForestWorkflow.kt
@@ -122,7 +122,7 @@ internal suspend fun AntForest.runForestHomeFollowUpWorkflow(selfHomeObj: JSONOb
                 useEnergyRainChanceCard()
                 tc.countDebug("使用能量雨卡")
             }
-            EnergyRainCoroutine.execEnergyRainCompat()
+            EnergyRainCoroutine.execEnergyRain()
             tc.countDebug("能量雨")
         } else {
             Log.forest(FOREST_TAG, "能量雨未到执行时间，跳过")

--- a/app/src/main/java/io/github/aoguai/sesameag/task/antForest/EnergyRainCoroutine.kt
+++ b/app/src/main/java/io/github/aoguai/sesameag/task/antForest/EnergyRainCoroutine.kt
@@ -1,6 +1,7 @@
 package io.github.aoguai.sesameag.task.antForest
 
 import io.github.aoguai.sesameag.data.Status
+import io.github.aoguai.sesameag.data.StatusFlags
 import io.github.aoguai.sesameag.hook.Toast
 import io.github.aoguai.sesameag.util.GameTask
 import io.github.aoguai.sesameag.util.FriendGuard
@@ -42,8 +43,9 @@ object EnergyRainCoroutine {
 
     /**
      * 执行能量雨功能
+     * @param isManual 是否为手动触发
      */
-    suspend fun execEnergyRain() {
+    suspend fun execEnergyRain(isManual: Boolean = false) {
         try {
             // 执行频率检查：防止短时间内重复执行
             val currentTime = System.currentTimeMillis()
@@ -55,7 +57,7 @@ object EnergyRainCoroutine {
                 delay(cooldownSeconds * 1000.toLong())
             }
 
-            energyRain()
+            energyRain(isManual)
 
             // 更新最后执行时间
             lastExecuteTime = System.currentTimeMillis()
@@ -70,8 +72,9 @@ object EnergyRainCoroutine {
 
     /**
      * 能量雨主逻辑（协程版本）
+     * @param isManual 是否为手动触发
      */
-    private suspend fun energyRain() {
+    private suspend fun energyRain(isManual: Boolean) {
         try {
             var playedCount = 0
             val maxPlayLimit = 10
@@ -84,136 +87,113 @@ object EnergyRainCoroutine {
                     break
                 }
                 val canPlayToday = joEnergyRainHome.optBoolean("canPlayToday", false)
-                val canPlayGame = joEnergyRainHome.optBoolean("canPlayGame", false)
+                val canPlayGame = joEnergyRainHome.optBoolean("canPlayGame", false) // 始终是true
                 val canGrantStatus = joEnergyRainHome.optBoolean("canGrantStatus", false)
+
+                var worked = false
 
                 // 1️⃣ 检查是否可以开始能量雨
                 if (canPlayToday) {
                     startEnergyRain()
                     playedCount++
                     randomDelay(3000, 5000) // 随机延迟3-5秒
-                    continue
+                    worked = true
                 }
 
                 // 2️⃣ 检查是否可以赠送能量雨
                 if (canGrantStatus) {
                     Log.forest(TAG, "有送能量雨的机会")
-                    val grantExceedFlag = "EnergyRain::grant_energy_rain_exceed"
-                    if (Status.hasFlagToday(grantExceedFlag)) {
-                        Log.forest(TAG, "今日已达到赠送能量雨上限，跳过赠送环节")
-                    } else {
-                        val joEnergyRainCanGrantList = JSONObject(AntForestRpcCall.queryEnergyRainCanGrantList())
-                        val grantInfos = joEnergyRainCanGrantList.optJSONArray("grantInfos") ?: org.json.JSONArray()
-                        val giveEnergyRainSet = AntForest.giveEnergyRainList?.value ?: emptySet()
-                        var granted = false
-                        var grantExceeded = false
+                    val joEnergyRainCanGrantList = JSONObject(AntForestRpcCall.queryEnergyRainCanGrantList())
+                    val grantInfos = joEnergyRainCanGrantList.optJSONArray("grantInfos") ?: org.json.JSONArray()
+                    val giveEnergyRainSet = AntForest.giveEnergyRainList!!.value
+                    var granted = false
 
-                        for (j in 0 until grantInfos.length()) {
-                            val grantInfo = grantInfos.getJSONObject(j)
-                            if (grantInfo.optBoolean("canGrantedStatus", false)) {
-                                val uid = grantInfo.getString("userId")
-                                if (giveEnergyRainSet.contains(uid)) {
-                                    if (FriendGuard.shouldSkipFriend(uid, TAG, "赠送能量雨")) {
-                                        continue
-                                    }
-                                    val rainJsonObj = JSONObject(AntForestRpcCall.grantEnergyRainChance(uid))
-                                    val maskedName = UserMap.getMaskName(uid)
-                                    val resultCode = rainJsonObj.optString("resultCode")
-                                    val resultDesc = rainJsonObj.optString("resultDesc")
-                                    Log.forest(TAG, "尝试送能量雨给【$maskedName】")
-                                    if (resultCode in SILENT_GRANT_FAILURE_CODES) {
-                                        when (resultCode) {
-                                            "RAIN_ENERGY_GRANT_EXCEED" -> {
-                                                Status.setFlagToday(grantExceedFlag)
-                                                Log.forest(TAG, "送能量雨已达到今日上限，停止继续尝试")
-                                                grantExceeded = true
-                                                break
-                                            }
-
-                                            "FRIEND_NOT_FOREST_USER" -> {
-                                                Log.forest(TAG, "跳过赠送【$maskedName】:${resultDesc.ifEmpty { "好友未开通蚂蚁森林" }}")
-                                            }
-
-                                            "RAIN_ENERGY_GRANTED_BY_OTHER" -> {
-                                                Log.forest(TAG, "跳过赠送【$maskedName】:${resultDesc.ifEmpty { "该好友已被其他人赠送" }}")
-                                            }
+                    for (j in 0 until grantInfos.length()) {
+                        val grantInfo = grantInfos.getJSONObject(j)
+                        if (grantInfo.optBoolean("canGrantedStatus", false)) {
+                            val uid = grantInfo.getString("userId")
+                            if (giveEnergyRainSet?.contains(uid) == true) {
+                                if (FriendGuard.shouldSkipFriend(uid, TAG, "赠送能量雨")) {
+                                    continue
+                                }
+                                val rainJsonObj = JSONObject(AntForestRpcCall.grantEnergyRainChance(uid))
+                                val maskedName = UserMap.getMaskName(uid)
+                                val resultCode = rainJsonObj.optString("resultCode")
+                                val resultDesc = rainJsonObj.optString("resultDesc")
+                                Log.forest(TAG, "尝试送能量雨给【$maskedName】")
+                                if (resultCode in SILENT_GRANT_FAILURE_CODES) {
+                                    when (resultCode) {
+                                        "RAIN_ENERGY_GRANT_EXCEED" -> {
+                                            Status.setFlagToday(StatusFlags.FLAG_FOREST_RAIN_GRANT_EXCEED)
+                                            Log.forest(TAG, "送能量雨已达到今日上限，停止继续尝试")
+                                            break
                                         }
-                                        continue
+
+                                        "FRIEND_NOT_FOREST_USER" -> {
+                                            Log.forest(TAG, "跳过赠送【$maskedName】:${resultDesc.ifEmpty { "好友未开通蚂蚁森林" }}")
+                                        }
+
+                                        "RAIN_ENERGY_GRANTED_BY_OTHER" -> {
+                                            Log.forest(TAG, "跳过赠送【$maskedName】:${resultDesc.ifEmpty { "该好友已被其他人赠送" }}")
+                                        }
                                     }
-                                    if (ResChecker.checkRes(TAG, rainJsonObj)) {
-                                        Log.forest(
-                                            "赠送能量雨机会给🌧️[$maskedName]#${
-                                                UserMap.getMaskName(
-                                                    UserMap.currentUid
-                                                )
-                                            }"
-                                        )
-                                        randomDelay(300, 400) // 随机延迟 300-400ms
-                                        granted = true
-                                        break
-                                    } else {
-                                        Log.error(TAG, "送能量雨失败 $rainJsonObj")
-                                    }
+                                    continue
+                                }
+                                if (ResChecker.checkRes(TAG, rainJsonObj)) {
+                                    Log.forest(
+                                        "赠送能量雨机会给🌧️[${UserMap.getMaskName(uid)}]#${
+                                            UserMap.getMaskName(
+                                                UserMap.currentUid
+                                            )
+                                        }"
+                                    )
+                                    randomDelay(300, 400) // 随机延迟 300-400ms
+                                    granted = true
+                                    break
+                                } else {
+                                    Log.error(TAG, "送能量雨失败 $rainJsonObj")
                                 }
                             }
                         }
-                        if (grantExceeded) {
-                            // 已达到上限：已记录并设置今日标记，无需继续提示
-                        } else if (granted) {
-                            continue
-                        } else {
-                            Log.forest(TAG, "今日无可送能量雨好友或已达到赠送上限")
-                        }
+                    }
+                    if (granted) {
+                        worked = true
+                    } else {
+                        Log.forest(TAG, "今日无可送能量雨好友或已达到赠送上限")
                     }
                 }
 
                 // 3️⃣ 检查是否可以能量雨游戏
                 // canPlayGame 好像一直是true        注意：能量雨游戏只能执行一次，执行后会设置标记防止重复
-                Log.forest(TAG, "是否可以能量雨游戏: $canPlayGame")
-
-                if (canPlayGame) {
-                    // 防止能量雨游戏重复执行
-                    val energyRainGameFlag = "EnergyRain::能量雨游戏任务"
-                    if (Status.hasFlagToday(energyRainGameFlag)) {
-                        break
+                val energyRainGameFlag = StatusFlags.FLAG_FOREST_RAIN_GAME_TASK
+                // 修复逻辑：只有常规机会用完 (!canPlayToday) 且赠送机会也已全部处理 (!canGrantStatus) 时，才检查收尾游戏任务
+                val canEnterGameCheck = isManual || (!canPlayToday && !canGrantStatus)
+                if (canEnterGameCheck) {
+                    if (canPlayGame && (isManual || !Status.hasFlagToday(energyRainGameFlag))) {
+                        Log.forest(TAG, "检查能量雨游戏任务")
+                        val taskResult = checkAndDoEndGameTask()//检查能量雨 游戏任务 并接取
+                        if (taskResult == TaskResult.SUCCESS) {
+                            randomDelay(3000, 5000) // 随机延迟3-5秒
+                            playedCount++
+                            worked = true
+                        } else if (taskResult == TaskResult.ALREADY_DONE && !isManual) {
+                            // 确定任务已完成或今日不可用，才设置标记
+                            Status.setFlagToday(energyRainGameFlag)
+                        }
                     }
-                    val hasTaskToProcess = checkAndDoEndGameTask()//检查能量雨 游戏任务 并接取
-                    randomDelay(3000, 5000) // 随机延迟3-5秒
-                    playedCount++
-                    // 只有当有实际任务需要处理时才继续循环
-                    if (hasTaskToProcess) {
-                        continue
-                    } else {
-                        // 没有任务需要处理，跳出循环
-                        Status.setFlagToday(energyRainGameFlag)
-                        break
+                } else if (!isManual && !Status.hasFlagToday(energyRainGameFlag)) {
+                    if (canPlayToday) {
+                        Log.forest(TAG, "跳过游戏任务检查：常规能量雨机会尚未耗尽。")
+                    } else if (canGrantStatus) {
+                        Log.forest(TAG, "跳过游戏任务检查：仍有赠送能量雨的机会。注意：游戏入口需在所有赠送机会消耗后开启，若当前无可送好友，请在[赠送能量雨配置]中勾选好友。")
                     }
                 }
 
-            /*
-                // 3️⃣ 检查能量雨游戏任务
-                val energyRainGameFlag = "EnergyRain::能量雨游戏任务"
-                if (!Status.hasFlagToday(energyRainGameFlag)) {
-                    Log.forest(TAG, "检查能量雨游戏任务")
-                    val hasTaskToProcess = checkAndDoEndGameTask()//检查能量雨 游戏任务
-                    randomDelay(3000, 5000) // 随机延迟3-5秒
-                    playedCount++
-                    // 只有当有实际任务需要处理时才继续循环
-                    if (hasTaskToProcess) {
-                        continue
-                    } else {
-                        // 设置能量雨游戏已执行标志
-                        Status.setFlagToday(energyRainGameFlag)
-                        break
-                    }
-                } else {
-                    // 今天已经执行过能量雨游戏任务，跳出循环
+                if (!worked) {
                     break
                 }
-            */
-
-                break
             } while (playedCount < maxPlayLimit)
+
             if (playedCount >= maxPlayLimit) {
                 Log.forest(TAG, "能量雨执行达到单次任务上限($maxPlayLimit)，停止执行")
             }
@@ -266,33 +246,40 @@ object EnergyRainCoroutine {
         }
     }
 
+    private enum class TaskResult {
+        SUCCESS,        // 执行成功
+        ALREADY_DONE,   // 任务已完成或确定不可用
+        NOT_FOUND       // 未发现任务（可能是接口更新延迟）
+    }
+
     /**
      * 检查并领取能量雨后的额外游戏任务
-     * @return Boolean 是否还有待处理的任务
      */
-    @JvmStatic
-    private suspend fun checkAndDoEndGameTask(): Boolean {
+    private suspend fun checkAndDoEndGameTask(): TaskResult {
         try {
             // 1. 查询当前是否有可接或已接的游戏任务
-            var jo = JSONObject(AntForestRpcCall.queryEnergyRainEndGameList())
+            var response = AntForestRpcCall.queryEnergyRainEndGameList()
+            var jo = JSONObject(response)
             if (!ResChecker.checkRes(TAG, jo)) {
-                //Log.error(TAG, "查询能量雨游戏任务失败 $jo")
-                return false
+                return TaskResult.NOT_FOUND
             }
 
-            // 2. 先处理“有新任务可以接”的情况
+            // 2. 先处理“有新任务可以接”的情况（需要初始化）
             if (jo.optBoolean("needInitTask", false)) {
+                Log.forest(TAG, "初始化能量雨机会任务...")
                 val initRes = JSONObject(AntForestRpcCall.initTask("GAME_DONE_SLJYD"))
-                if (!ResChecker.checkRes(TAG, initRes)) {
-                    return false
-                }
-                jo = JSONObject(AntForestRpcCall.queryEnergyRainEndGameList())
-                if (!ResChecker.checkRes(TAG, jo)) {
-                    return false
+                if (ResChecker.checkRes(TAG, initRes)) {
+                    randomDelay(1000, 2000)
+                    // 🚀 核心修复：初始化后必须刷新列表，否则下面的 Step 3 使用的是旧数据
+                    response = AntForestRpcCall.queryEnergyRainEndGameList()
+                    jo = JSONObject(response)
+                    if (!ResChecker.checkRes(TAG, jo)) return TaskResult.NOT_FOUND
+                } else {
+                    return TaskResult.NOT_FOUND
                 }
             }
 
-            // 3. 核心逻辑：遍历任务列表，检查是否有处于 TODO 状态的任务
+            // 3. 核心逻辑：遍历任务列表，检查是否有处于 TO DO 状态的任务
             val groupTask = jo.optJSONObject("energyRainEndGameGroupTask")
             val taskInfoList = groupTask?.optJSONArray("taskInfoList")
             if (taskInfoList != null && taskInfoList.length() > 0) {
@@ -300,35 +287,37 @@ object EnergyRainCoroutine {
                     val task = taskInfoList.getJSONObject(i)
                     val baseInfo = task.optJSONObject("taskBaseInfo") ?: continue
                     val taskType = baseInfo.optString("taskType")
-                    val taskStatus = baseInfo.optString("taskStatus")
-                    if (taskType != "GAME_DONE_SLJYD") {
-                        continue
-                    }
-                    if (taskStatus == "TODO" || taskStatus == "NOT_TRIGGER") {
-                        GameTask.Forest_sljyd.report(1)
-                        return true
-                    }
-                    if (taskStatus == "FINISHED" || taskStatus == "DONE") {
-                        return false
+                    val taskStatus = baseInfo.optString("taskStatus") // 关键状态
+
+                    if (taskType == "GAME_DONE_SLJYD") {
+                        if (taskStatus == "TODO" || taskStatus == "NOT_TRIGGER") {
+                            val bizInfoStr = baseInfo.optString("bizInfo")
+                            val taskTitle = if (bizInfoStr.isNotEmpty()) {
+                                JSONObject(bizInfoStr).optString("taskTitle", "能量雨游戏任务")
+                            } else {
+                                "能量雨游戏任务"
+                            }
+
+                            Log.forest(TAG, "发现待完成任务[$taskTitle]，准备执行上报...")
+                            AntForestRpcCall.clickGame("2021005113684028")
+                            randomDelay(2000, 3000)
+                            if (GameTask.Forest_sljyd.report(1)) {
+                                Log.forest(TAG, "森林能量雨机会任务[$taskTitle] 已完成")
+                                return TaskResult.SUCCESS
+                            }
+                            return TaskResult.NOT_FOUND
+                        } else if (taskStatus == "FINISHED" || taskStatus == "DONE") {
+                            Log.forest(TAG, "能量雨机会任务今日已完成")
+                            return TaskResult.ALREADY_DONE
+                        }
                     }
                 }
             }
-
-            // 4. 如果没有找到任何待处理的任务，返回false
-            return false
-        } catch (th: Throwable) {
-            //Log.printStackTrace(TAG, "执行能量雨后续任务出错:", th)
-            return false
-        }
-    }
-
-    /**
-     * 兼容Java调用的包装方法
-     */
-    @JvmStatic
-    fun execEnergyRainCompat() {
-        kotlinx.coroutines.runBlocking {
-            execEnergyRain()
+            // 没找到特定任务
+            return TaskResult.ALREADY_DONE
+        } catch (e: Exception) {
+            Log.forest(TAG, "检查能量雨任务异常: ${e.message}")
+            return TaskResult.NOT_FOUND
         }
     }
 }

--- a/app/src/main/java/io/github/aoguai/sesameag/util/GameTask.kt
+++ b/app/src/main/java/io/github/aoguai/sesameag/util/GameTask.kt
@@ -80,27 +80,32 @@ enum class GameTask(
     }
 
     /**
-     * 外部调用：执行上报任务
+     * 外部调用：执行上报任务 (改为协程版本)
+     * @return Boolean 任务是否至少成功执行了一次上报或整体完成
      */
-    suspend fun report(eggCount: Int) {
+    suspend fun report(eggCount: Int): Boolean {
         val totalNeeded = (eggCount * requestsPerEgg) + 1 //正常不需要加1，多1次确保网络请求不会错误
 
         cachedToken = login()
         if (cachedToken.isNullOrEmpty()) {
             logTask("⚠️ 无法获取有效的 Token，放弃上报任务")
-            return
+            return false
         }
 
+        var successCount = 0
         //Log.record(title, "🚀 开始执行任务：目标 $eggCount 个蛋，需请求 $totalNeeded 次")
         for (i in 1..totalNeeded) {
             // 执行单次上报
-            if (!executeSingleReport(i, totalNeeded)) {
-                // 具体的错误原因已在 executeSingleReport 中详细输出
+            if (executeSingleReport(i, totalNeeded)) {
+                successCount++
+            } else {
+                // 如果第一次就失败，或者中途由于 Token 失效等原因失败
                 break
             }
             if (i < totalNeeded) delay((1000..3000).random().toLong())
         }
         //Log.record(title, "🏁 任务流程运行结束")
+        return successCount > 0
     }
 
     private fun executeSingleReport(current: Int, total: Int): Boolean {


### PR DESCRIPTION
1.完善森林能量雨游戏得能量雨机会判断，必须消耗完所有能量雨机会才会出现入口，否则无法在一次任务中完成所有能量雨任务。 
2.修改手动任务执行能量雨为忽略hasFlagToday判定
3.修改GameTask.report可以返回是否成功执行
4.选择能量雨开关、兑换开关、分享一个好友机会，这三项可以保证回出玩游戏的入口并自动完成游戏任务+50g。+好友回赠的一次机会，总计380g。如果好友提前赠送你一次机会，在一次运行时即可直接获得380g。即使好友后来才赠送机会，后续运行也可正确执行。