### PR TITLE
庄园加速卡用户自定义限制逻辑调整

### DIFF
--- a/app/src/main/java/io/github/aoguai/sesameag/task/antFarm/AntFarm.kt
+++ b/app/src/main/java/io/github/aoguai/sesameag/task/antFarm/AntFarm.kt
@@ -2609,22 +2609,26 @@ class AntFarm : ModelTask() {
         return dailyLimitValue >= 0 && Status.INSTANCE.useAccelerateToolCount >= dailyLimitValue
     }
 
+    /**
+     * 检测加速卡限制原因
+     * @param syncFlag 是否同步持久化标记。
+     */
     private fun detectAccelerateToolLimit(syncFlag: Boolean = false): AccelerateToolLimitReason? {
         if (Status.hasFlagToday(StatusFlags.FLAG_FARM_ACCELERATE_LIMIT)) {
             return AccelerateToolLimitReason.FLAGGED
         }
+
         if (!Status.canUseAccelerateTool()) {
             if (syncFlag) {
                 Status.setFlagToday(StatusFlags.FLAG_FARM_ACCELERATE_LIMIT)
             }
             return AccelerateToolLimitReason.SYSTEM_LIMIT
         }
+
         if (hasReachedConfiguredAccelerateToolLimit()) {
-            if (syncFlag) {
-                Status.setFlagToday(StatusFlags.FLAG_FARM_ACCELERATE_LIMIT)
-            }
             return AccelerateToolLimitReason.USER_LIMIT
         }
+
         return null
     }
 


### PR DESCRIPTION
1.移除触发用户配置限制时设置持久化标记 `FLAG_FARM_ACCELERATE_LIMIT` 的逻辑。这样用户调整自定义加速卡数量或取消限制后仍能补齐使用加速卡。