### PR TITLE
AntOcean 任务处理逻辑优化与重构

### DIFF
--- a/app/src/main/java/io/github/aoguai/sesameag/data/Status.kt
+++ b/app/src/main/java/io/github/aoguai/sesameag/data/Status.kt
@@ -8,8 +8,15 @@ import io.github.aoguai.sesameag.util.JsonUtil
 import io.github.aoguai.sesameag.util.Log
 import io.github.aoguai.sesameag.util.TimeUtil
 import io.github.aoguai.sesameag.util.maps.UserMap
+import org.json.JSONObject
+import java.text.SimpleDateFormat
 import java.util.Calendar
 import java.util.Date
+import java.util.Locale
+import kotlin.collections.component1
+import kotlin.collections.component2
+import kotlin.collections.get
+import kotlin.collections.set
 
 class Status {
 
@@ -75,11 +82,29 @@ class Status {
     var memberSignInList: MutableSet<String> = HashSet()
     val flagList: MutableSet<String> = HashSet()
 
+    /** 模块化标记与计数存储 (Key: 模块名, Value: Map<标记名, 次数>) */
+    var moduleFlags: MutableMap<String, MutableMap<String, Int>> = HashMap()
+
     /** 口碑签到 */
     var kbSignIn: Long = 0
 
-    /** 保存时间 */
-    var saveTime: Long = 0L
+    /** 上次任务启动时间 */
+    var lastTaskTime: Long = 0L
+
+    /** 预定的下次任务执行时间 */
+    var nextExecutionTime: Long = 0L
+
+    /** 🚀 新增：上次高优任务（能量|小鸡任务）启动时间 */
+    var lastCoreTaskTime: Long = 0L
+
+    /** 持久化身份锚定：标记此内存状态属于哪个用户 */
+    var currentUid: String? = null
+
+    /** 保存时间：默认为创建时刻，确保新对象不会被判定为“跨天” */
+    var saveTime: Long = System.currentTimeMillis()
+
+    /** 是否正在运行主任务 (用于进程重启检测) */
+    var isTaskRunning: Boolean = false
 
     /** 新村助力好友，已上限的用户 */
     var antStallAssistFriend: MutableSet<String> = HashSet()
@@ -99,11 +124,44 @@ class Status {
     /** 会员权益 */
     var memberPointExchangeBenefitLogList: MutableSet<String> = HashSet()
 
+    /**
+     * 检查今日已完成状态（实例方法，供 ModelFieldTodayStateResolver 使用）
+     */
+    fun hasFlagTodayInstance(flag: String, retryLimit: Int = 0, retryTimes: String? = null): Boolean {
+        val (module, name) = parseFlag(flag)
+        val flags = moduleFlags[module] ?: return false
+        val currentCount = flags[name] ?: return false
+        if (retryLimit > 0 && currentCount < retryLimit) return false
+        if (!retryTimes.isNullOrEmpty()) {
+            val sdf = SimpleDateFormat("HHmm", Locale.getDefault())
+            val nowTime = sdf.format(Date(System.currentTimeMillis()))
+            val timeArray = retryTimes.split(",")
+            for (t in timeArray) {
+                val threshold = t.trim()
+                if (nowTime >= threshold && !flags.containsKey("${name}_$threshold")) {
+                    return false
+                }
+            }
+        }
+        return true
+    }
+
+    /**
+     * 获取今日整型标记（实例方法）
+     */
+    fun getIntFlagTodayInstance(flag: String): Int? {
+        val (module, name) = parseFlag(flag)
+        return moduleFlags[module]?.get(name)
+    }
+
     companion object {
         private val TAG = Status::class.java.simpleName
 
         @JvmStatic
         val INSTANCE: Status = Status()
+
+        private var lastModifiedTime: Long = 0L
+        private var lastUid: String? = null
 
         @JvmStatic
         val currentDayTimestamp: Long
@@ -115,6 +173,33 @@ class Status {
                 calendar.set(Calendar.MILLISECOND, 0)
                 return calendar.timeInMillis
             }
+
+        private fun parseFlag(flag: String): Pair<String, String> {
+            val index = flag.indexOf("::")
+            return if (index > 0) {
+                flag.substring(0, index) to flag.substring(index + 2)
+            } else {
+                "general" to flag
+            }
+        }
+
+        /**
+         * 🚀 核心新增：加载一个独立的状态实例而不影响 INSTANCE
+         */
+        @JvmStatic
+        fun loadStandalone(userId: String): Status? {
+            try {
+                val statusFile = Files.getStatusFile(userId) ?: return null
+                if (!statusFile.exists()) return null
+                val json = Files.readFromFile(statusFile)
+                if (json.isBlank()) return null
+                val status = JsonUtil.parseObject(json, Status::class.java)
+                return status
+            } catch (e: Exception) {
+                Log.e(TAG, "Failed to load standalone status for $userId", e)
+                return null
+            }
+        }
 
         @JvmStatic
         fun getVitalityCount(skuId: String): Int {
@@ -553,40 +638,71 @@ class Status {
         @Synchronized
         @JvmStatic
         fun load(currentUid: String?): Status {
+            return load(currentUid, true)
+        }
+
+        @Synchronized
+        @JvmStatic
+        fun load(currentUid: String?, showLog: Boolean): Status {
             if (currentUid.isNullOrEmpty()) {
-                Log.record(TAG, "用户为空，状态加载失败")
+                if (showLog) Log.record(TAG, "用户为空，状态加载失败")
                 throw RuntimeException("用户为空，状态加载失败")
             }
+
             try {
                 val statusFile = Files.getStatusFile(currentUid)
                 if (statusFile!!.exists()) {
-                    Log.record(TAG, "加载 status.json")
-                    val json = Files.readFromFile(statusFile)
-                    if (json.trim().isNotEmpty()) {
-                        // 使用 Jackson 更新现有对象
-                        JsonUtil.copyMapper().readerForUpdating(INSTANCE).readValue<Status>(json)
-                        // 格式化检查
-                        val formatted = JsonUtil.formatJson(INSTANCE)
-                        if (formatted != json) {
-                            Log.record(TAG, "重新格式化 status.json")
-                            Files.write2File(formatted, statusFile)
-                        }
+                    val fileTime = statusFile.lastModified()
+                    val isUserChanged = currentUid != lastUid
+
+                    // 缓存检查：如果 UID 和文件修改时间都没变，跳过 IO
+                    if (!isUserChanged && fileTime != 0L && fileTime == lastModifiedTime) {
+                        // 同一用户重复加载，不打印 record 日志
                     } else {
-                        Log.record(TAG, "配置文件为空，初始化默认配置")
-                        initializeDefaultConfig(statusFile)
+                        if (showLog) {
+                            if (isUserChanged) Log.record(TAG, "加载用户[$currentUid]的 status.json")
+                            else Log.record(TAG, "加载 status.json")
+                        }
+
+                        val json = Files.readFromFile(statusFile)
+                        if (json.trim().isNotEmpty()) {
+                            JsonUtil.copyMapper().readerForUpdating(INSTANCE).readValue(json, Status::class.java)
+
+                            val formatted = JsonUtil.formatJson(INSTANCE)
+                            if (formatted != json) {
+                                if (showLog) Log.record(TAG, "重新格式化 status.json")
+                                Files.write2File(formatted, statusFile)
+                            }
+                            lastModifiedTime = statusFile.lastModified()
+                            lastUid = currentUid
+                            // 🚩 关键：修正加载后的身份
+                            INSTANCE.currentUid = currentUid
+                        } else {
+                            if (showLog) Log.record(TAG, "配置文件为空，初始化默认配置")
+                            initializeDefaultConfig(statusFile)
+                        }
                     }
                 } else {
-                    Log.record(TAG, "配置文件不存在，初始化默认配置")
+                    if (showLog) Log.record(TAG, "配置文件不存在，初始化默认配置")
                     initializeDefaultConfig(statusFile)
                 }
             } catch (t: Throwable) {
                 Log.printStackTrace(TAG, t)
-                Log.record(TAG, "状态文件格式有误，已重置")
+                if (showLog) Log.record(TAG, "状态文件格式有误，已重置")
                 resetAndSaveConfig()
             }
 
-            // 这里逻辑有点奇怪，如果 saveTime 是 0，则设为当前时间。
-            // 原始 Java 代码中 Long 默认为 null，但这里属性初始化为 0L。
+            // 无论加载还是初始化，确保身份锚定
+            if (INSTANCE.currentUid == null) INSTANCE.currentUid = currentUid
+
+            // 无论是否命中缓存，日期检查逻辑保持不变
+            if (updateDay(Calendar.getInstance())) {
+                if (showLog) Log.record(TAG, "发现日期更新，重置 status.json 状态")
+                // 如果过期重置了，重新确保新日期的身份和时间有效
+                INSTANCE.currentUid = currentUid
+                INSTANCE.saveTime = System.currentTimeMillis()
+            }
+
             if (INSTANCE.saveTime == 0L) {
                 INSTANCE.saveTime = System.currentTimeMillis()
             }
@@ -597,7 +713,12 @@ class Status {
             try {
                 JsonUtil.copyMapper().updateValue(INSTANCE, Status())
                 Log.record(TAG, "初始化 status.json")
+                INSTANCE.currentUid = UserMap.currentUid
+                INSTANCE.saveTime = System.currentTimeMillis()
                 Files.write2File(JsonUtil.formatJson(INSTANCE), statusFile)
+                // 同步缓存标记
+                lastModifiedTime = statusFile.lastModified()
+                lastUid = UserMap.currentUid
             } catch (e: JsonMappingException) {
                 Log.printStackTrace(TAG, e)
                 throw RuntimeException("初始化配置失败", e)
@@ -607,7 +728,13 @@ class Status {
         private fun resetAndSaveConfig() {
             try {
                 JsonUtil.copyMapper().updateValue(INSTANCE, Status())
-                Files.write2File(JsonUtil.formatJson(INSTANCE), Files.getStatusFile(UserMap.currentUid)!!)
+                val statusFile = Files.getStatusFile(UserMap.currentUid)!!
+                INSTANCE.currentUid = UserMap.currentUid
+                INSTANCE.saveTime = System.currentTimeMillis()
+                Files.write2File(JsonUtil.formatJson(INSTANCE), statusFile)
+                // 同步缓存标记
+                lastModifiedTime = statusFile.lastModified()
+                lastUid = UserMap.currentUid
             } catch (e: JsonMappingException) {
                 Log.printStackTrace(TAG, e)
                 throw RuntimeException("重置配置失败", e)
@@ -620,9 +747,13 @@ class Status {
             try {
                 // 创建新状态实例并确保清空所有每日标记
                 val newStatus = Status()
-                // 确保清空flagList
+                // 确保清空所有标记和计数
                 INSTANCE.flagList.clear()
+                INSTANCE.moduleFlags.clear()
                 JsonUtil.copyMapper().updateValue(INSTANCE, newStatus)
+                // 清除缓存标记，强制下次加载重新读取
+                lastModifiedTime = 0L
+                lastUid = null
             } catch (e: JsonMappingException) {
                 Log.printStackTrace(TAG, e)
             }
@@ -631,11 +762,18 @@ class Status {
         @Synchronized
         @JvmStatic
         fun save(nowCalendar: Calendar = Calendar.getInstance()) {
-            val currentUid = UserMap.currentUid
-            if (currentUid.isNullOrEmpty()) {
+            val targetUid = UserMap.currentUid
+            if (targetUid.isNullOrEmpty()) {
                 Log.record(TAG, "用户为空，状态保存失败")
-                throw RuntimeException("用户为空，状态保存失败")
+                throw RuntimeException("用户为空，状态加载失败")
             }
+
+            // 🚩 核心防御：如果内存里的 UID 与当前全局 UID 不符，说明处于切换中，严禁写入
+            if (INSTANCE.currentUid != null && INSTANCE.currentUid != targetUid) {
+                Log.record(TAG, "拒绝跨账号保存: Memory(${INSTANCE.currentUid}) -> Disk($targetUid)")
+                return
+            }
+
             if (updateDay(nowCalendar)) {
                 Log.record(TAG, "重置 status.json")
             } else {
@@ -643,8 +781,13 @@ class Status {
             }
             val lastSaveTime = INSTANCE.saveTime
             try {
+                INSTANCE.currentUid = targetUid
                 INSTANCE.saveTime = System.currentTimeMillis()
-                Files.write2File(JsonUtil.formatJson(INSTANCE), Files.getStatusFile(currentUid)!!)
+                val statusFile = Files.getStatusFile(targetUid)!!
+                Files.write2File(JsonUtil.formatJson(INSTANCE), statusFile)
+                // 关键：更新标记，防止下一次 load 触发冗余读取
+                lastModifiedTime = statusFile.lastModified()
+                lastUid = targetUid
             } catch (e: Exception) {
                 INSTANCE.saveTime = lastSaveTime
                 throw e
@@ -687,19 +830,16 @@ class Status {
         }
 
         /**
-         * ## 设置今日已运行状态
-         * @param flag tagName::done
+         * ## 检查今日已运行状态
+         * @param flag 标记名，支持 "Module::Task"格式
+         * @param retryLimit 允许运行的最大次数。0 表示不限制次数（只要 flag 存在即拦截）
+         * @param retryTimes 重试时间点，格式 "0800,1200"。到达时间点后允许再次运行。
+         * @return true 表示“已完成/需拦截”，false 表示“未完成/需运行”
          */
         @JvmStatic
-        fun hasFlagToday(flag: String): Boolean {
-            return INSTANCE.flagList.contains(flag)
-        }
-
-        @JvmStatic
-        fun setFlagToday(flag: String) {
-            if (INSTANCE.flagList.add(flag)) {
-                save()
-            }
+        @JvmOverloads
+        fun hasFlagToday(flag: String, retryLimit: Int = 0, retryTimes: String? = null): Boolean {
+            return INSTANCE.hasFlagTodayInstance(flag, retryLimit, retryTimes)
         }
 
         @JvmStatic
@@ -711,32 +851,116 @@ class Status {
         }
 
         /**
-         * 带 UID 保护的“今日标记”。
-         *
-         * 用于规避：任务执行过程中切号导致 Status 标记写入到下一个账号的极少数情况。
+         * ## 完善的标记设置逻辑 (单次或分时段)
+         * 1. 自动过滤重复调用，仅在状态变更时保存，降低 I/O 损耗。
+         * 2. 支持分时段逻辑，确保每个时间点仅触发一次更新。
          */
         @JvmStatic
-        fun setFlagToday(flag: String, taskUid: String?) {
-            if (taskUid.isNullOrBlank()) {
-                setFlagToday(flag)
-                return
+        @JvmOverloads
+        fun setFlagToday(flag: String, retryTimes: String? = null) {
+            val (module, name) = parseFlag(flag)
+            val flags = INSTANCE.moduleFlags.getOrPut(module) { HashMap() }
+            val oldCount = flags[name] ?: 0
+
+            var changed = false
+            val nowTime = SimpleDateFormat("HHmm", Locale.getDefault()).format(Date())
+
+            if (oldCount == 0) {
+                flags[name] = 1
+                changed = true
             }
-            if (taskUid != UserMap.currentUid) return
-            if (INSTANCE.flagList.add(flag)) {
+
+            if (!retryTimes.isNullOrEmpty()) {
+                retryTimes.split(",").forEach {
+                    val threshold = it.trim()
+                    if (nowTime >= threshold) {
+                        val slotKey = "${name}_$threshold"
+                        if (flags[slotKey] != 1) {
+                            flags[slotKey] = 1
+                            changed = true
+                            // 此时增加总计数，代表进入了新阶段
+                            flags[name] = (flags[name] ?: 0) + 1
+                        }
+                    }
+                }
+            }
+
+            if (changed) {
                 save()
             }
         }
 
-        // 2025/12/4 用来获取 自定义flag的int
+        /**
+         * 🚀 完善的 RPC 结果自动补标记工具
+         * 适配光盘打卡、健康岛签到等“远程已完成”场景。
+         * @param jo RPC 返回的 JSONObject
+         * @param extraDoneCodes 额外的“视为完成”的 resultCode 或 errorCode
+         */
         @JvmStatic
-        fun getIntFlagToday(key: String): Int? {
-            return INSTANCE.intFlagMap[key]
+        fun setFlagIfDone(flag: String, jo: JSONObject?, vararg extraDoneCodes: String) {
+            if (jo == null) return
+            val resultCode = jo.optString("resultCode")
+            val errorCode = jo.optString("errorCode")
+            val success = jo.optBoolean("success") || jo.optBoolean("isSuccess") ||
+                    "SUCCESS" == jo.optString("memo")
+
+            val isAlreadyDone = resultCode == "ACTION_ALREADY_TICKED" ||
+                    resultCode == "ALREADY_SIGN_IN" ||
+                    errorCode == "ALREADY_SIGN_IN" ||
+                    extraDoneCodes.any { it == resultCode || it == errorCode }
+
+            if (success || isAlreadyDone) {
+                setFlagToday(flag)
+            }
+        }
+
+        /**
+         * 清除今日标记
+         * 支持 "Module::Task" 格式，兼容 flagList 和 moduleFlags
+         */
+        @JvmStatic
+        fun removeFlag(flag: String) {
+            var changed = false
+            val (module, name) = parseFlag(flag)
+
+            // 1. 从 moduleFlags 中移除
+            INSTANCE.moduleFlags[module]?.let {
+                if (it.remove(name) != null) {
+                    changed = true
+                }
+                // 同时移除带时间点的子标记（如 Task_0800）
+                val keysToRemove = it.keys.filter { key -> key.startsWith("${name}_") }
+                if (keysToRemove.isNotEmpty()) {
+                    keysToRemove.forEach { k -> it.remove(k) }
+                    changed = true
+                }
+            }
+
+            // 2. 从旧的 flagList 中移除
+            if (INSTANCE.flagList.remove(flag)) {
+                changed = true
+            }
+
+            if (changed) {
+                save()
+            }
         }
 
         @JvmStatic
-        fun setIntFlagToday(key: String, value: Int) {
-            INSTANCE.intFlagMap[key] = value
-            save()
+        fun getIntFlagToday(flag: String): Int? {
+            return INSTANCE.getIntFlagTodayInstance(flag)
+        }
+
+        @JvmStatic
+        fun setIntFlagToday(flag: String, value: Int) {
+            val (module, name) = parseFlag(flag)
+            val flags = INSTANCE.moduleFlags.getOrPut(module) { HashMap() }
+
+            // 仅当数值确实不同时才保存，避免冗余 I/O
+            if (flags[name] != value) {
+                flags[name] = value
+                save()
+            }
         }
 
         @JvmStatic
@@ -762,6 +986,22 @@ class Status {
         fun canParadiseCoinExchangeBenefitToday(spuId: String): Boolean {
             return !hasFlagToday(StatusFlags.FLAG_FARM_PARADISE_COIN_EXCHANGE_LIMIT_PREFIX + spuId)
         }
+
+        @JvmStatic
+        fun getFlagModuleNames(): List<String> {
+            return INSTANCE.moduleFlags.keys.toList()
+        }
+
+        @JvmStatic
+        fun getFlagsByModule(module: String): List<String> {
+            return INSTANCE.moduleFlags[module]?.keys?.filter { !it.contains("_") }?.toList() ?: emptyList()
+        }
+
+        @JvmStatic
+        fun clearModuleFlags(module: String) {
+            if (INSTANCE.moduleFlags.remove(module) != null) {
+                save()
+            }
+        }
     }
 }
-

--- a/app/src/main/java/io/github/aoguai/sesameag/task/antOcean/AntOcean.kt
+++ b/app/src/main/java/io/github/aoguai/sesameag/task/antOcean/AntOcean.kt
@@ -1,6 +1,5 @@
 package io.github.aoguai.sesameag.task.antOcean
 
-import com.fasterxml.jackson.core.type.TypeReference
 import io.github.aoguai.sesameag.data.Status
 import io.github.aoguai.sesameag.data.StatusFlags
 import io.github.aoguai.sesameag.entity.AlipayBeach
@@ -14,14 +13,11 @@ import io.github.aoguai.sesameag.model.modelFieldExt.BooleanModelField
 import io.github.aoguai.sesameag.model.modelFieldExt.ChoiceModelField
 import io.github.aoguai.sesameag.model.modelFieldExt.SelectAndCountModelField
 import io.github.aoguai.sesameag.model.modelFieldExt.SelectModelField
-import io.github.aoguai.sesameag.util.ActionDelayUtil
-import io.github.aoguai.sesameag.util.DataStore
 import io.github.aoguai.sesameag.util.FriendGuard
 import io.github.aoguai.sesameag.task.ModelTask
 import io.github.aoguai.sesameag.task.TaskCommon
 import io.github.aoguai.sesameag.task.TaskStatus
 import io.github.aoguai.sesameag.task.antForest.AntForestRpcCall
-import io.github.aoguai.sesameag.util.GlobalThreadPools
 import io.github.aoguai.sesameag.util.JsonUtil
 import io.github.aoguai.sesameag.util.Log
 import io.github.aoguai.sesameag.util.maps.BeachMap
@@ -36,6 +32,7 @@ import kotlinx.coroutines.isActive
 import org.json.JSONArray
 import org.json.JSONException
 import org.json.JSONObject
+import java.util.HashSet
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.AtomicInteger
 
@@ -165,6 +162,7 @@ class AntOcean : ModelTask() {
     private var PDL_task: BooleanModelField? = null
 
     private val oceanTaskTryCount = ConcurrentHashMap<String, AtomicInteger>()
+    private val loggedMessages = HashSet<String>()
 
     private fun buildOceanTaskBizKey(sceneCode: String, taskType: String, taskTitle: String): String {
         return "$sceneCode|$taskType|$taskTitle"
@@ -1256,28 +1254,12 @@ class AntOcean : ModelTask() {
 
     private suspend fun receiveTaskAward() {
         try {
-            val presetBad = LinkedHashSet(listOf("DEMO", "DEMO1"))
-            val badTaskSetSchemaVersion = 2
-            val badTaskSetSchemaKey = "badOceanTaskSetSchemaVersion"
-            val typeRef = object : TypeReference<MutableSet<String>>() {}
-            var badTaskSet = DataStore.getOrCreate("badOceanTaskSet", typeRef)
-            val storedSchemaVersion = DataStore.getOrCreate<Int>(badTaskSetSchemaKey)
-            if (storedSchemaVersion != badTaskSetSchemaVersion) {
-                badTaskSet.clear()
-                badTaskSet.addAll(presetBad)
-                DataStore.put("badOceanTaskSet", badTaskSet)
-                DataStore.put(badTaskSetSchemaKey, badTaskSetSchemaVersion)
-            }
-            if (badTaskSet.isEmpty()) {
-                badTaskSet.addAll(presetBad)
-                DataStore.put("badOceanTaskSet", badTaskSet)
-            }
-                        while (currentCoroutineContext().isActive) {
+            while (currentCoroutineContext().isActive) {
                 var done = false
                 val s = AntOceanRpcCall.queryTaskList()
                 val jo = JsonUtil.parseJSONObjectOrNull(s) ?: break
                 if (!ResChecker.checkRes(TAG, jo)) {
-                    Log.ocean(TAG, "查询任务列表失败：" + jo.getString("resultDesc"))
+                    Log.ocean("查询任务列表失败：" + jo.getString("resultDesc"))
                     break
                 }
                 val jaTaskList = jo.optJSONArray("antOceanTaskVOList") ?: break
@@ -1293,39 +1275,8 @@ class AntOcean : ModelTask() {
                     val sceneCode = task.getString("sceneCode")
                     val taskType = task.getString("taskType")
                     val taskStatus = task.getString("taskStatus")
-                    val bizKey = buildOceanTaskBizKey(sceneCode, taskType, taskTitle)
 
-                    // 在处理任何任务前，先检查当日限制，再检查黑名单
-                    if (Status.hasFlagToday(StatusFlags.FLAG_ANTOCEAN_HELP_CLEAN_ALL_FRIEND_LIMIT) &&
-                        (taskTitle.contains("帮好友清理") || taskType.contains("HELP_CLEAN"))
-                    ) {
-                        if (rememberOceanTaskAttempt(bizKey) == 1) {
-                            Log.ocean(TAG, "海洋任务🌊[$taskTitle]帮助清理次数已达上限，跳过处理")
-                        }
-                        continue
-                    }
-                    if (badTaskSet.contains(taskTitle) ||
-                        badTaskSet.contains(taskType) ||
-                        TaskBlacklist.isTaskInBlacklist(taskTitle) ||
-                        TaskBlacklist.isTaskInBlacklist(taskType)
-                    ) {
-                        if (rememberOceanTaskAttempt(bizKey) == 1) {
-                            Log.ocean(TAG, "海洋任务🌊[$taskTitle]已在黑名单中，跳过处理")
-                        }
-                        continue
-                    }
-
-                    if (!isRewardReadyStatus(taskStatus) && isSelfCleanTask(taskType, taskTitle)) {
-                        if (retrySelfOceanCleanIfNeeded(taskTitle)) {
-                            done = true
-                        }
-                        continue
-                    }
-
-                    if (!isRewardReadyStatus(taskStatus) && isOceanActionTask(taskType, taskTitle)) {
-                        continue
-                    }
-
+                    // 1. 领奖分支：只要是可领奖状态，无论是否在黑名单，都优先领奖
                     if (isRewardReadyStatus(taskStatus)) {
                         val awardResponse = AntOceanRpcCall.receiveTaskAward(sceneCode, taskType)
                         val joAward = JsonUtil.parseJSONObjectOrNull(awardResponse) ?: continue
@@ -1336,100 +1287,56 @@ class AntOcean : ModelTask() {
                             Log.error(TAG, "海洋奖励🌊领取失败：$joAward")
                         }
                     } else if (TaskStatus.TODO.name == taskStatus) {
+                        // 2. 待办分支
+                        // 仅在 TO DO 状态检查黑名单
+                        if (TaskBlacklist.isTaskInBlacklist(taskTitle) ||
+                            TaskBlacklist.isTaskInBlacklist(taskType)
+                        ) {
+                            val msg = "海洋任务🌊[$taskTitle]已在黑名单中，跳过处理"
+                            if (loggedMessages.add(msg)) {
+                                Log.ocean(msg)
+                            }
+                            continue
+                        }
+
+                        // 清理任务限制检查
+                        if (Status.hasFlagToday(StatusFlags.FLAG_ANTOCEAN_HELP_CLEAN_ALL_FRIEND_LIMIT) &&
+                            (taskTitle.contains("帮好友清理") || taskType.contains("HELP_CLEAN"))
+                        ) {
+                            val msg = "海洋任务🌊[$taskTitle]帮助清理次数已达上限，跳过处理"
+                            if (loggedMessages.add(msg)) {
+                                Log.ocean(msg)
+                            }
+                            continue
+                        }
+
+                        // 拦截清理类动作，不通过 RPC 完成 TO DO
+                        if (isSelfCleanTask(taskType, taskTitle)) {
+                            if (retrySelfOceanCleanIfNeeded(taskTitle)) {
+                                done = true
+                            }
+                            continue
+                        }
+                        if (isOceanActionTask(taskType, taskTitle)) {
+                            continue
+                        }
+
+                        // 处理其它任务
                         if (taskTitle.contains("答题")) {
                             if (answerQuestion()) {
                                 done = true
                             }
                         } else {
-                            val waitSeconds = resolveOceanTaskWaitSeconds(taskTitle, bizInfo)
-                            if (waitSeconds > 0) {
-                                val finishSource = resolveOceanTaskFinishSource(taskType, taskTitle, bizInfo)
-                                val safeByRpc = isOceanTimedBrowseTaskSafeByRpc(taskType, taskTitle, bizInfo)
-                                val count = rememberOceanTaskAttempt(bizKey)
-                                if (count > 1) {
-                                    if (count == 2) {
-                                        val duplicateReason = if (safeByRpc) "浏览任务本轮已尝试过" else "未支持任务本轮已记录过"
-                                        Log.ocean(
-                                            TAG,
-                                            "海洋任务🌊[$taskTitle]$duplicateReason，后续静默跳过[taskType=$taskType]"
-                                        )
-                                    }
-                                    continue
-                                }
-                                if (!safeByRpc) {
-                                    Log.ocean(
-                                        TAG,
-                                        "海洋任务🌊[$taskTitle]广告/高风险浏览任务待支持[wait=${waitSeconds}s][taskType=$taskType][source=$finishSource]，跳过处理"
-                                    )
-                                    continue
-                                }
-
-                                val waitMillis = resolveOceanTaskWaitMillis(waitSeconds)
-                                Log.ocean(
-                                    TAG,
-                                    "海洋任务🌊[$taskTitle]开始等待${waitSeconds}s后尝试RPC完成[taskType=$taskType]"
-                                )
-                                ActionDelayUtil.humanActionDelay(500L)
-                                delay(waitMillis)
-
-                                val sourcesToTry = listOf(finishSource)
-                                var joFinishTask: JSONObject? = null
-                                var finishOk = false
-                                var notSupportedCount = 0
-
-                                for (source in sourcesToTry) {
-                                    val finishResponse = AntOceanRpcCall.finishTask(sceneCode, taskType, source)
-                                    val parsed = JsonUtil.parseJSONObjectOrNull(finishResponse) ?: continue
-                                    joFinishTask = parsed
-
-                                    val errorCode = parsed.optString("code", "")
-                                    val desc = parsed.optString("desc", "")
-                                    if (errorCode == "400000040" || desc.contains("不支持RPC完成")) {
-                                        notSupportedCount++
-                                        continue
-                                    }
-
-                                    if (ResChecker.checkRes(TAG, parsed)) {
-                                        finishOk = true
-                                        break
-                                    }
-                                }
-
-                                if (finishOk) {
-                                    oceanTaskTryCount.remove(bizKey)
-                                    Log.ocean("海洋任务🌊完成[$taskTitle]")
-                                    done = true
-                                } else if (notSupportedCount >= sourcesToTry.size) {
-                                    Log.ocean(
-                                        TAG,
-                                        "海洋任务🌊[$taskTitle]浏览任务暂不支持RPC完成[wait=${waitSeconds}s][taskType=$taskType][source=$finishSource]，保持跳过"
-                                    )
-                                } else {
-                                    val finishResult = joFinishTask
-                                    if (finishResult == null) {
-                                        Log.error(
-                                            TAG,
-                                            "海洋任务🌊浏览任务完成失败[$taskTitle][taskType=$taskType][waitSec=$waitSeconds][waitMillis=$waitMillis][source=$finishSource]: 响应为空"
-                                        )
-                                    } else {
-                                        Log.error(
-                                            TAG,
-                                            "海洋任务🌊浏览任务完成失败[$taskTitle][taskType=$taskType][waitSec=$waitSeconds][waitMillis=$waitMillis][source=$finishSource]: ${extractOceanResultDesc(finishResult)}"
-                                        )
-                                    }
-                                }
-
-                                delay(500)
-                                continue
-                            }
-
-                            val count = rememberOceanTaskAttempt(bizKey)
+                            val bizKey = "${sceneCode}_$taskType"
+                            val count = oceanTaskTryCount.computeIfAbsent(bizKey) { AtomicInteger(0) }
+                                    .incrementAndGet()
 
                             val finishSource = resolveOceanTaskFinishSource(taskType, taskTitle, bizInfo)
                             val fallbackSource = if (finishSource == "ADBASICLIB") "ANTFOCEAN" else "ADBASICLIB"
                             val sourcesToTry = listOf(finishSource, fallbackSource).distinct()
-                            var joFinishTask: JSONObject? = null
+
                             var finishOk = false
+                            var joFinishTask: JSONObject? = null
                             var notSupportedCount = 0
 
                             for (source in sourcesToTry) {
@@ -1437,7 +1344,6 @@ class AntOcean : ModelTask() {
                                 val parsed = JsonUtil.parseJSONObjectOrNull(finishResponse) ?: continue
                                 joFinishTask = parsed
 
-                                // 检查特定错误码：不支持RPC完成的任务，仅在两种 source 都不支持时再加入黑名单
                                 val errorCode = parsed.optString("code", "")
                                 val desc = parsed.optString("desc", "")
                                 if (errorCode == "400000040" || desc.contains("不支持RPC完成")) {
@@ -1452,10 +1358,8 @@ class AntOcean : ModelTask() {
                             }
 
                             if (!finishOk && notSupportedCount >= sourcesToTry.size) {
-                                Log.error(TAG, "海洋任务🌊[$taskTitle]不支持RPC完成，已加入黑名单")
-                                badTaskSet.add(taskTitle)
-                                badTaskSet.add(taskType)
-                                DataStore.put("badOceanTaskSet", badTaskSet)
+                                Log.ocean("海洋任务🌊[$taskTitle]不支持RPC完成，已加入黑名单")
+                                TaskBlacklist.addToBlacklist(taskType, taskTitle)
                                 continue
                             }
 
@@ -1467,13 +1371,10 @@ class AntOcean : ModelTask() {
                             } else {
                                 Log.error(TAG, "海洋任务🌊完成失败：$finishResult")
                                 if (count > 1) {
-                                    badTaskSet.add(taskTitle)
-                                    badTaskSet.add(taskType)
-                                    DataStore.put("badOceanTaskSet", badTaskSet)
+                                    TaskBlacklist.addToBlacklist(taskType, taskTitle)
                                 }
                             }
                         }
-
                         delay(500)
                     }
                 }

--- a/app/src/main/java/io/github/aoguai/sesameag/task/antOcean/AntOcean.kt
+++ b/app/src/main/java/io/github/aoguai/sesameag/task/antOcean/AntOcean.kt
@@ -1288,9 +1288,10 @@ class AntOcean : ModelTask() {
                         }
                     } else if (TaskStatus.TODO.name == taskStatus) {
                         // 2. 待办分支
+                        val moduleName = getName()
                         // 仅在 TO DO 状态检查黑名单
-                        if (TaskBlacklist.isTaskInBlacklist(taskTitle) ||
-                            TaskBlacklist.isTaskInBlacklist(taskType)
+                        if (TaskBlacklist.isTaskInBlacklist(moduleName, taskTitle) ||
+                            TaskBlacklist.isTaskInBlacklist(moduleName, taskType)
                         ) {
                             val msg = "海洋任务🌊[$taskTitle]已在黑名单中，跳过处理"
                             if (loggedMessages.add(msg)) {
@@ -1359,7 +1360,7 @@ class AntOcean : ModelTask() {
 
                             if (!finishOk && notSupportedCount >= sourcesToTry.size) {
                                 Log.ocean("海洋任务🌊[$taskTitle]不支持RPC完成，已加入黑名单")
-                                TaskBlacklist.addToBlacklist(taskType, taskTitle)
+                                TaskBlacklist.addToBlacklist(moduleName, taskType, taskTitle)
                                 continue
                             }
 
@@ -1371,7 +1372,7 @@ class AntOcean : ModelTask() {
                             } else {
                                 Log.error(TAG, "海洋任务🌊完成失败：$finishResult")
                                 if (count > 1) {
-                                    TaskBlacklist.addToBlacklist(taskType, taskTitle)
+                                    TaskBlacklist.addToBlacklist(moduleName, taskType, taskTitle)
                                 }
                             }
                         }

--- a/app/src/main/java/io/github/aoguai/sesameag/util/TaskBlacklist.kt
+++ b/app/src/main/java/io/github/aoguai/sesameag/util/TaskBlacklist.kt
@@ -1,6 +1,7 @@
 package io.github.aoguai.sesameag.util
 
 import com.fasterxml.jackson.core.type.TypeReference
+import kotlin.collections.any
 
 /**
  * 通用任务黑名单管理器
@@ -10,15 +11,56 @@ object TaskBlacklist {
     private const val TAG = "TaskBlacklist"
     private const val BLACKLIST_KEY = "task_blacklist"
 
+    private fun getAllBlacklists(): Map<String, Set<String>> {
+        return try {
+            DataStore.getOrCreate(BLACKLIST_KEY, object : TypeReference<Map<String, Set<String>>>() {})
+        } catch (e: Exception) {
+            Log.printStackTrace(TAG, "获取黑名单列表失败", e)
+            emptyMap()
+        }
+    }
+
+    /**
+     * 保存完整的黑名单映射
+     */
+    private fun saveAllBlacklists(blacklists: Map<String, Set<String>>) {
+        try {
+            DataStore.put(BLACKLIST_KEY, blacklists)
+        } catch (e: Exception) {
+            Log.printStackTrace(TAG, "保存黑名单失败", e)
+        }
+    }
+
+    /**
+     * 获取所有有黑名单的模块名称
+     */
+    fun getBlacklistModuleNames(): List<String> {
+        return getAllBlacklists().keys.toList()
+    }
+
+    /**
+     * 获取指定模块的黑名单
+     */
+    fun getBlacklist(moduleName: String?): Set<String> {
+        if (moduleName.isNullOrBlank()) return emptySet()
+        return getAllBlacklists()[moduleName] ?: emptySet()
+    }
+
     /**
      * 获取黑名单列表
      * @return 黑名单任务集合
      */
     fun getBlacklist(): Set<String> {
         return try {
-            val storedBlacklist = DataStore.getOrCreate(BLACKLIST_KEY, object : TypeReference<Set<String>>() {})
-            // 合并存储的黑名单和默认黑名单
-            (storedBlacklist + defaultBlacklist).toSet()
+            // 优先从所有模块中合并
+            val allStored = getAllBlacklists().values.flatten().toSet()
+            if (allStored.isNotEmpty()) {
+                (allStored + defaultBlacklist).toSet()
+            } else {
+                // 兼容旧格式
+                val storedBlacklist = DataStore.getOrCreate(BLACKLIST_KEY, object : TypeReference<Set<String>>() {})
+                (storedBlacklist + defaultBlacklist).toSet()
+            }
         } catch (e: Exception) {
             Log.printStackTrace(TAG, "获取黑名单失败，使用默认黑名单", e)
             defaultBlacklist
@@ -39,131 +81,181 @@ object TaskBlacklist {
         }
     }
 
-    
-    
     /**
-     * 检查任务是否在黑名单中（精确匹配逻辑）
-     * @param taskInfo 任务信息（可以是任务ID、任务标题或组合信息）
-     * @return true表示在黑名单中，应该跳过
+     * 检查任务是否在黑名单中
+     * 采用包含匹配逻辑，确保 ID 或 标题 任意一项命中即可
+     */
+    fun isTaskInBlacklist(moduleName: String?, taskInfo: String?): Boolean {
+        if (taskInfo.isNullOrBlank()) return false
+        if (moduleName.isNullOrBlank()) return isTaskInBlacklist(taskInfo)
+
+        // 1. 检查内置黑名单
+        DEFAULT_BLACKLIST[moduleName]?.let { defaultSet ->
+            if (defaultSet.any { isMatch(taskInfo, it) }) return true
+        }
+
+        // 2. 检查持久化存储的黑名单
+        val moduleBlacklist = getBlacklist(moduleName)
+        return moduleBlacklist.any { isMatch(taskInfo, it) }
+    }
+
+    /**
+     * 兼容旧版调用，检查任务是否在任意模块的黑名单中
      */
     fun isTaskInBlacklist(taskInfo: String?): Boolean {
         if (taskInfo.isNullOrBlank()) return false
-        
-        val blacklist = getBlacklist()
-        return blacklist.any { item ->
-            if (item.isBlank()) return@any false
 
-            // 完全匹配（最精确）
-            if (taskInfo == item) return@any true
+        // 1. 检查所有内置黑名单
+        if (DEFAULT_BLACKLIST.values.any { set -> set.any { isMatch(taskInfo, it) } }) return true
 
-            // 区分处理中文关键词和纯英文的匹配模式。
-            val itemHasChinese = item.any { it in '\u4e00'..'\u9fa5' }
+        // 2. 检查所有持久化存储的黑名单
+        return getAllBlacklists().values.any { set -> set.any { isMatch(taskInfo, it) } }
+    }
 
-            if (itemHasChinese) {
-                // 包含中文的项维持双向模糊匹配逻辑
-                taskInfo.contains(item) || item.contains(taskInfo)
+    /**
+     * 统一的匹配逻辑
+     * @param input 传入的待检查字符串 (通常是 taskId)
+     * @param blacklistItem 黑名单中的项 (通常是 taskId + taskTitle)
+     */
+    private fun isMatch(input: String, blacklistItem: String): Boolean {
+        if (blacklistItem.isBlank()) return false
+
+        // 1. 完全匹配
+        if (input == blacklistItem) return true
+
+        // 2. 分隔符匹配（如果黑名单项包含 | 分隔符，说明是新格式）
+        if (blacklistItem.contains('|')) {
+            val parts = blacklistItem.split('|')
+            return parts.any { part ->
+                if (part.isBlank()) return@any false
+                if (input == part) return@any true
+                // 如果 input 包含中文（标题），则允许包含匹配
+                val inputHasChinese = input.any { it in '\u4e00'..'\u9fa5' }
+                if (inputHasChinese) {
+                    return@any input.contains(part) || part.contains(input)
+                }
+                false
+            }
+        }
+
+        // 3. 兼容旧格式（IDTitle）
+        val itemHasChinese = blacklistItem.any { it in '\u4e00'..'\u9fa5' }
+        val inputHasChinese = input.any { it in '\u4e00'..'\u9fa5' }
+
+        return if (itemHasChinese) {
+            if (!inputHasChinese) {
+                // 如果 input 是 ID（无中文），尝试更精确的匹配：ID 必须是黑名单项的前缀，且后面紧跟中文
+                if (blacklistItem.startsWith(input)) {
+                    val nextIdx = input.length
+                    if (nextIdx < blacklistItem.length && blacklistItem[nextIdx] in '\u4e00'..'\u9fa5') {
+                        return true
+                    }
+                }
+                false
             } else {
-                /* 纯英文/数字/符号项使用单向模糊匹配逻辑；防止黑名单中"TAOBAO"这类比较简短、通用的字段匹配到任务
-                    "TAOBAO_tab2gzy" ，导致不是在黑名单中的任务被跳过
-                 */
-                item.contains(taskInfo)
+                // 如果 input 也是标题（含中文），则维持包含匹配
+                blacklistItem.contains(input) || input.contains(blacklistItem)
             }
+        } else {
+            // 黑名单项无中文（可能是纯 ID），则要求 input 包含黑名单项（常规关键词匹配）
+            input.contains(blacklistItem)
         }
     }
-    
+
     /**
-     * 添加任务到黑名单
-     * @param taskId 要添加的任务ID
-     * @param taskTitle 任务标题（可选，用于模糊匹配）
+     * 添加任务到指定模块的黑名单
      */
-    fun addToBlacklist(taskId: String, taskTitle: String = "") {
+    fun addToBlacklist(moduleName: String?, taskId: String, taskTitle: String = "") {
+        if (moduleName.isNullOrBlank() || taskId.isBlank()) return
+
+        // 使用分隔符 | 拼接 ID 和 标题，便于后续精确匹配
+        val blacklistItem = if (taskTitle.isNotBlank() && taskId != taskTitle) "$taskId|$taskTitle" else taskId
+        val allBlacklists = getAllBlacklists().toMutableMap()
+        val moduleSet = allBlacklists[moduleName]?.toMutableSet() ?: mutableSetOf()
+
+        if (moduleSet.add(blacklistItem)) {
+            allBlacklists[moduleName] = moduleSet
+            saveAllBlacklists(allBlacklists)
+        }
+    }
+
+    /**
+     * 从指定模块的黑名单中移除任务
+     */
+    fun removeFromBlacklist(moduleName: String?, taskId: String, taskTitle: String = "") {
+        if (moduleName.isNullOrBlank() || taskId.isBlank()) return
+
+        val blacklistItem = if (taskTitle.isNotBlank() && taskId != taskTitle) "$taskId|$taskTitle" else taskId
+        val allBlacklists = getAllBlacklists().toMutableMap()
+        val moduleSet = allBlacklists[moduleName]?.toMutableSet() ?: return
+
+        if (moduleSet.remove(blacklistItem)) {
+            allBlacklists[moduleName] = moduleSet
+            saveAllBlacklists(allBlacklists)
+            Log.record(TAG, "模块[$moduleName]的任务[$blacklistItem]已从黑名单移除")
+        }
+    }
+
+    /**
+     * 清空指定模块的黑名单
+     */
+    fun clearBlacklist(moduleName: String?) {
+        if (moduleName.isNullOrBlank()) return
+        val allBlacklists = getAllBlacklists().toMutableMap()
+        if (allBlacklists.remove(moduleName) != null) {
+            saveAllBlacklists(allBlacklists)
+            Log.record(TAG, "模块[$moduleName]的黑名单已清空")
+        }
+    }
+
+    /**
+     * 清空所有模块的黑名单
+     */
+    fun clearAllBlacklists() {
+        saveAllBlacklists(emptyMap())
+        Log.record(TAG, "所有任务黑名单已清空")
+    }
+
+    /**
+     * 兼容旧版调用，自动添加任务到黑名单
+     */
+    fun autoAddToBlacklist(taskId: String, taskTitle: String, errorCode: String) {
+        autoAddToBlacklist("未分类", taskId, taskTitle, errorCode)
+    }
+
+    /**
+     * 自动添加任务到模块黑名单
+     */
+    fun autoAddToBlacklist(moduleName: String?, taskId: String, taskTitle: String = "", errorCode: String) {
         if (taskId.isBlank()) return
-        // 如果提供了任务标题，则将ID和标题组合后添加，支持模糊匹配
-        val blacklistItem = if (taskTitle.isNotBlank()) "$taskId$taskTitle" else taskId
-        val currentBlacklist = getBlacklist().toMutableSet()
-        if (currentBlacklist.add(blacklistItem)) {
-            saveBlacklist(currentBlacklist)
+        val finalModuleName = if (moduleName.isNullOrBlank()) "未分类" else moduleName
+
+        var shouldAutoAdd = false
+        var reason = ""
+
+        when {
+            errorCode == "400000040" -> { shouldAutoAdd = true; reason = "不支持rpc调用" }
+            errorCode == "CAMP_TRIGGER_ERROR" -> { shouldAutoAdd = true; reason = "活动触发错误" }
+            errorCode == "OP_REPEAT_CHECK" -> { shouldAutoAdd = true; reason = "操作太频繁" }
+            errorCode == "ILLEGAL_ARGUMENT" -> { shouldAutoAdd = true; reason = "参数错误" }
+            errorCode == "104" || errorCode == "PROMISE_HAS_PROCESSING_TEMPLATE" -> {
+                shouldAutoAdd = true; reason = "存在进行中的记录"
+            }
+            errorCode == "TASK_ID_INVALID" -> { shouldAutoAdd = true; reason = "任务ID非法" }
+            errorCode == "PROMISE_TEMPLATE_NOT_EXIST" || errorCode == "生活记录模板不存在" -> {
+                shouldAutoAdd = true; reason = "模板不存在"
+            }
+            errorCode.contains("系统繁忙") || errorCode.contains("稍后再试") -> {
+                shouldAutoAdd = true; reason = "系统繁忙/稍后再试"
+            }
+            errorCode == "FAKE_SUCCESS" -> { shouldAutoAdd = true; reason = "检测到伪成功" }
+            errorCode == "10000005" -> { shouldAutoAdd = true; reason = "海豚服务异常" }
         }
-    }
-    
-    /**
-     * 从黑名单中移除任务
-     * @param taskId 要移除的任务ID
-     * @param taskTitle 任务标题（可选，用于模糊匹配）
-     */
-    fun removeFromBlacklist(taskId: String, taskTitle: String = "") {
-        if (taskId.isBlank()) return
-        
-        // 如果提供了任务标题，则将ID和标题组合后移除，支持模糊匹配
-        val blacklistItem = if (taskTitle.isNotBlank()) "$taskId$taskTitle" else taskId
-        
-        val currentBlacklist = getBlacklist().toMutableSet()
-        if (currentBlacklist.remove(blacklistItem)) {
-            saveBlacklist(currentBlacklist)
-            val displayInfo = if (taskTitle.isNotBlank()) "$taskId - $taskTitle" else taskId
-            Log.record(TAG, "任务[$displayInfo]已从黑名单移除")
-        }
-    }
-    
-    /**
-     * 清空黑名单
-     */
-    fun clearBlacklist() {
-        try {
-            saveBlacklist(emptySet())
-            Log.record(TAG, "黑名单已清空")
-        } catch (e: Exception) {
-            Log.printStackTrace(TAG, "清空黑名单失败", e)
-        }
-    }
-    
-    /**
-     * 根据错误码自动添加任务到黑名单
-     * 当任务执行失败时，如果错误码属于预定义的无法恢复的错误类型，
-     * 系统会自动将该任务加入黑名单，避免重复执行失败的任务
-     * 
-     * @param taskId 任务ID，用于标识具体任务
-     * @param taskTitle 任务标题（可选），用于显示和模糊匹配
-     * @param errorCode 错误码，用于判断是否需要自动加入黑名单
-     */
-    fun autoAddToBlacklist(taskId: String, taskTitle: String = "", errorCode: String) {
-        // 参数校验：如果任务ID为空，直接返回
-        if (taskId.isBlank()) return
-        // 第一步：判断当前错误码是否需要自动加入黑名单
-        // 只有特定的、无法通过重试解决的错误才会自动加入黑名单
-        val shouldAutoAdd = when (errorCode) {
-            // 农场任务特有的错误：后端不支持RPC调用
-            "400000040" -> true
-            "CAMP_TRIGGER_ERROR", // 以下错误码都会导致任务自动加入黑名单：
-            "104",
-            "OP_REPEAT_CHECK",               // 操作频率过高，被系统限制
-            "ILLEGAL_ARGUMENT",              // 参数不合法或格式错误
-            "PROMISE_HAS_PROCESSING_TEMPLATE", // 存在进行中的生活记录
-            "PROMISE_TEMPLATE_NOT_EXIST" -> true // 服务端模板已下线
-            "TASK_ID_INVALID" -> true        // 海豚任务ID非法
-            else -> false                    // 其他错误码不自动加入黑名单
-        }
-        
-        // 第二步：如果确定需要自动加入黑名单
+
         if (shouldAutoAdd) {
-            // 调用添加方法，将任务ID和标题组合后加入黑名单（支持模糊匹配）
-            addToBlacklist(taskId, taskTitle)
-            // 第三步：根据错误码生成用户友好的错误说明
-            val reason = when (errorCode) {
-                "400000040" -> "不支持rpc调用"
-                "CAMP_TRIGGER_ERROR" -> "海豚活动触发错误"
-                "OP_REPEAT_CHECK" -> "操作太频繁"
-                "ILLEGAL_ARGUMENT" -> "参数错误"
-                "104", "PROMISE_HAS_PROCESSING_TEMPLATE" -> "存在进行中的生活记录"
-                "PROMISE_TEMPLATE_NOT_EXIST" -> "服务端模板不存在"
-                "TASK_ID_INVALID" -> "任务ID非法"
-                else -> "未知错误"  // 理论上不会执行到此处
-            }
-            
-            // 第四步：生成日志信息并记录
-            // 优先显示完整信息（ID-标题），如果标题为空则只显示ID
+            addToBlacklist(finalModuleName, taskId, taskTitle)
             val taskInfo = if (taskTitle.isNotBlank()) "$taskId - $taskTitle" else taskId
-            Log.record(TAG, "任务[$taskInfo]因$reason 自动加入黑名单")
+            Log.record(TAG, "模块[$finalModuleName]任务[$taskInfo]因$reason 自动加入黑名单")
         }
     }
 }

--- a/app/src/main/java/io/github/aoguai/sesameag/util/defaultBlacklist.kt
+++ b/app/src/main/java/io/github/aoguai/sesameag/util/defaultBlacklist.kt
@@ -2,18 +2,6 @@ package io.github.aoguai.sesameag.util
 
 /**
  * 默认黑名单列表（包含常见无法完成、暂无稳定 RPC 或长期仅支持手动完成的任务）
- *
- * 数据来源：
- * 已确认不支持 RPC 的高频任务，避免误杀可领取/可完成的日常任务
- *
- * 使用方法：
- * 1. 检查任务是否在黑名单中（模糊匹配）：
- *    if (TaskBlacklist.isTaskInBlacklist(taskInfo)) { 跳过任务 }
- * 2. 根据错误码自动添加任务到黑名单：
- *    TaskBlacklist.autoAddToBlacklist(taskId, taskTitle, errorCode)
- * 3. 手动添加/移除任务：
- *    TaskBlacklist.addToBlacklist(taskId)
- *    TaskBlacklist.removeFromBlacklist(taskId)
  */
 
 private fun mergeDefaultBlacklist(vararg groups: Set<String>): Set<String> =
@@ -143,10 +131,61 @@ private val oceanDefaultBlacklist = setOf(
 
 private val forestDefaultBlacklist = setOf(
     // 蚂蚁森林
-    "ZHRW_AQapp_202512",   // 去蚂蚁阿福健康问答
+    "ENERGY_XUANJIAO_huanbaobei环保杯",
+    "ENERGY_XUANJIAO_zhiyinshui直饮水",
+    "ENERGY_XUANJIAO_dianzibaodan电子保单",
+    "ENERGY_XUANJIAO_gongjiaochuxing公交出行",
+    "ENERGY_XUANJIAO_lvsejiazhuang绿色家装",
+    "ENERGY_XUANJIAO_shenghuojiaofei生活缴费",
+    "ENERGY_XUANJIAO_lvsezhengwu绿色政务",
+    "ENERGY_XUANJIAO_saomagoupiao扫码购票",
+    "ENERGY_XUANJIAO_lvseruzhu绿色入住",
+    "ENERGY_XUANJIAO_tingchejiaofei停车缴费",
+    "ENERGY_XUANJIAO_lvsehuishou绿色回收",
+    "ENERGY_XUANJIAO_xinyongzhu信用住",
+    "ENERGY_XUANJIAO_wangshangjijian网上寄件",
+    "ENERGY_XUANJIAO_gongxiangdanche共享单车",
+    "ENERGY_XUANJIAO_gongxiangzulin共享租赁",
+    "ENERGY_XUANJIAO_gongxianchongdianbao共享充电宝",
+    "ENERGY_XUANJIAO_lvseyinhang绿色银行",
+    "ENERGY_XUANJIAO_dianzizhangdan电子账单",
+    "ENERGY_XUANJIAO_faxianlvseshenhuo探动植物",
+    "ENERGY_XUANJIAO_lvsebaozhuang绿色包装",
+    "ENERGY_XUANJIAO_etcjiaofeiETC缴费",
+    "ENERGY_XUANJIAO_linqishipin临期食品",
+    "ENERGY_XUANJIAO_lvsechexian绿色车险",
+    "ENERGY_XUANJIAO_lvsewaimai绿色外卖",
+    "ENERGY_XUANJIAO_xinnengyuanzuche新能源租车",
+    "ENERGY_XUANJIAO_wuzhihuayuedu无纸化阅读",
+    "ENERGY_XUANJIAO_tushujieyue图书借阅",
+    "ENERGY_XUANJIAO_cheliangtingshi车辆停驶",
+    "ENERGY_XUANJIAO_lvsefeixing绿色飞行",
+    "ENERGY_XUANJIAO_dianzixiaopiao电子小票",
+    "ENERGY_XUANJIAO_xianshanghuankuan线上还款",
+    "ENERGY_XUANJIAO_saomadiandan扫码点单",
+    "ENERGY_XUANJIAO_lvseyiliao绿色医疗",
+    "ZHRW_AQapp_202512去蚂蚁阿福健康问答",
+    "ENERGY_XUANJIAO_xianxiazhifu线下支付",
+    "ENERGY_XUANJIAO_dianzifapiao电子发票",
+    "ENERGY_XUANJIAO_huanbaojiansu环保减塑",
+    "widget_100g_202509添加组件及时收能量",
+    "ENERGY_XUANJIAO_wanggouhuochepiao网购火车票",
+    "ENERGY_XUANJIAO_xingzou行走",
+    "ENERGY_XUANJIAO_wangluogoupiao网络购票",
+    "SHARETASK_NEW邀请1位好友助力",
+    "ENERGY_XUANJIAO_lvsechangguan绿色场馆",
+    "ENERGY_XUANJIAO_daxinnengyuanche打新能源车",
+    "ENERGY_XUANJIAO_guojituishui国际退税",
+    "ENERGY_XUANJIAO_dianzijiayou电子加油",
+    "ENERGY_XUANJIAO_lvsejiadian绿色家电",
+    "ENERGY_XUANJIAO_gonggongchongdianzhuang公共充电桩",
+    "ENERGY_XUANJIAO_lvsebangong绿色办公",
+    "ENERGY_XUANJIAO_ditiechuxing地铁出行",
+    "ENERGY_XUANJIAO_guangpanxingdong光盘行动",
+    "ENERGY_XUANJIAO_dianzizhifu电子支付",
+    "FOREST_CONTINUOUS_COLLECT_ENERGY_7连续7天收自己能量",
     "LSHS_huisho20_202508", // 完成旧衣回收得能量
     "TEST_LEAF_TASK",      // 逛农场得落叶肥料
-    "SHARETASK_NEW",       // 邀请1位好友助力
     "YUSHU_202511",        // 单种榆树，年年有榆
     "KTKZ_YS202511",       // 一起组团种榆树
     "mokuai_senlin_hlz"    // 去玩一玩得活力值
@@ -196,6 +235,19 @@ private val memberDefaultBlacklist = setOf(
 
 private val sportsDefaultBlacklist = emptySet<String>()
 
+val DEFAULT_BLACKLIST: Map<String, Set<String>> = mapOf(
+    "芝麻信用" to sesameCreditDefaultBlacklist,
+    "芝麻炼金" to sesameAlchemyDefaultBlacklist,
+    "芭芭农场" to orchardDefaultBlacklist,
+    "蚂蚁庄园" to farmDefaultBlacklist,
+    "神奇海洋" to oceanDefaultBlacklist,
+    "蚂蚁森林" to forestDefaultBlacklist,
+    "余额宝" to yuebaoDefaultBlacklist,
+    "黄金票" to goldTicketDefaultBlacklist,
+    "支付宝会员" to memberDefaultBlacklist,
+    "运动" to sportsDefaultBlacklist
+)
+
 val defaultBlacklist: Set<String> = mergeDefaultBlacklist(
     sesameCreditDefaultBlacklist,
     sesameAlchemyDefaultBlacklist,
@@ -208,4 +260,3 @@ val defaultBlacklist: Set<String> = mergeDefaultBlacklist(
     memberDefaultBlacklist,
     sportsDefaultBlacklist
 )
-


### PR DESCRIPTION
- 移除本地 `badTaskSet` 存储逻辑，统一接入 `TaskBlacklist` 管理黑名单任务。
- 调整任务处理优先级，确保在检查黑名单前优先领取已完成任务的奖励。
- 优化日志输出逻辑，引入 `loggedMessages` 过滤重复的“跳过任务”提示。
- 简化 RPC 任务完成流程，移除复杂的浏览任务等待及安全校验逻辑。
- 修复任务尝试次数计数的 key 生成方式，并优化不支持 RPC 任务的拦截处理。

我就直接推我的方法了。