### PR TITLE
日志滚动策略优化及跨天处理逻辑完善

### DIFF
--- a/app/src/main/java/io/github/aoguai/sesameag/util/Log.kt
+++ b/app/src/main/java/io/github/aoguai/sesameag/util/Log.kt
@@ -51,6 +51,8 @@ object Log {
     }
 
     private fun logRaw(channel: LogChannel, severity: Severity, msg: String) {
+        Logback.refreshIfCrossDay()
+
         if (!shouldWrite(channel)) {
             return
         }
@@ -63,15 +65,21 @@ object Log {
         }
     }
 
-    private fun write(channel: LogChannel, severity: Severity, msg: String) {
-        if (channel.mirrorToRecord) {
-            logRaw(LogChannel.RECORD, Severity.INFO, msg)
+
+    private fun write(channel: LogChannel, severity: Severity, msg: String, type: Int = 1) {
+        if (channel.mirrorToRecord && type == 1) {
+            val recordMsg = if (!channel.logTag.isNullOrEmpty()) {
+                formatTaggedMessage(channel.logTag, msg)
+            } else {
+                msg
+            }
+            logRaw(LogChannel.RECORD, Severity.INFO, recordMsg)
         }
         logRaw(channel, severity, msg)
     }
 
-    private fun business(channel: LogChannel, msg: String) {
-        write(channel, Severity.INFO, msg)
+    private fun business(channel: LogChannel, msg: String, type: Int = 1) {
+        write(channel, Severity.INFO, msg, type)
     }
 
     @JvmStatic
@@ -95,13 +103,18 @@ object Log {
     }
 
     @JvmStatic
-    fun record(msg: String) {
-        write(LogChannel.RECORD, Severity.INFO, msg)
+    fun record(msg: String, type: Int = 1) {
+        logRaw(LogChannel.RUNTIME, Severity.DEBUG, msg)
+
+        val shouldRecord = if (type == 1) shouldWrite(LogChannel.RECORD) else false
+        if (shouldRecord) {
+            logRaw(LogChannel.RECORD, Severity.INFO, msg)
+        }
     }
 
     @JvmStatic
-    fun record(tag: String, msg: String) {
-        record(formatTaggedMessage(tag, msg))
+    fun record(tag: String, msg: String, type: Int = 1) {
+        record(formatTaggedMessage(tag, msg), type)
     }
 
     @JvmStatic
@@ -125,13 +138,15 @@ object Log {
     }
 
     @JvmStatic
-    fun forest(msg: String) {
-        business(LogChannel.FOREST, msg)
+    @JvmOverloads
+    fun forest(msg: String, type: Int = 1) {
+        business(LogChannel.FOREST, msg, type)
     }
 
     @JvmStatic
-    fun forest(tag: String, msg: String) {
-        forest(formatTaggedMessage(tag, msg))
+    @JvmOverloads
+    fun forest(tag: String, msg: String, type: Int = 1) {
+        forest(formatTaggedMessage(tag, msg), type)
     }
 
     @JvmStatic
@@ -145,13 +160,15 @@ object Log {
     }
 
     @JvmStatic
-    fun farm(msg: String) {
-        business(LogChannel.FARM, msg)
+    @JvmOverloads
+    fun farm(msg: String, type: Int = 1) {
+        business(LogChannel.FARM, msg, type)
     }
 
     @JvmStatic
-    fun farm(tag: String, msg: String) {
-        farm(formatTaggedMessage(tag, msg))
+    @JvmOverloads
+    fun farm(tag: String, msg: String, type: Int = 1) {
+        farm(formatTaggedMessage(tag, msg), type)
     }
 
     @JvmStatic

--- a/app/src/main/java/io/github/aoguai/sesameag/util/LogCatalog.kt
+++ b/app/src/main/java/io/github/aoguai/sesameag/util/LogCatalog.kt
@@ -44,7 +44,8 @@ enum class LogChannel(
     val description: String,
     val viewerGroup: LogViewerGroup? = null,
     val mirrorToRecord: Boolean = false,
-    val visibleInViewer: Boolean = false
+    val visibleInViewer: Boolean = false,
+    val logTag: String? = null
 ) {
     SYSTEM(
         loggerName = "system",
@@ -70,7 +71,7 @@ enum class LogChannel(
         description = "任务调度与执行统计摘要",
         viewerGroup = LogViewerGroup.OVERVIEW,
         mirrorToRecord = true,
-        visibleInViewer = true,
+        visibleInViewer = true
     ),
     COMMON(
         loggerName = "common",
@@ -91,6 +92,7 @@ enum class LogChannel(
         viewerGroup = LogViewerGroup.MODULES,
         mirrorToRecord = true,
         visibleInViewer = true,
+        logTag = "森林"
     ),
     ORCHARD(
         loggerName = "orchard",
@@ -101,6 +103,7 @@ enum class LogChannel(
         viewerGroup = LogViewerGroup.MODULES,
         mirrorToRecord = true,
         visibleInViewer = true,
+        logTag = "农场"
     ),
     FARM(
         loggerName = "farm",
@@ -111,6 +114,7 @@ enum class LogChannel(
         viewerGroup = LogViewerGroup.MODULES,
         mirrorToRecord = true,
         visibleInViewer = true,
+        logTag = "庄园"
     ),
     STALL(
         loggerName = "stall",
@@ -121,6 +125,7 @@ enum class LogChannel(
         viewerGroup = LogViewerGroup.MODULES,
         mirrorToRecord = true,
         visibleInViewer = true,
+        logTag = "新村"
     ),
     OCEAN(
         loggerName = "ocean",
@@ -131,6 +136,7 @@ enum class LogChannel(
         viewerGroup = LogViewerGroup.MODULES,
         mirrorToRecord = true,
         visibleInViewer = true,
+        logTag = "海洋"
     ),
     MEMBER(
         loggerName = "member",
@@ -141,6 +147,7 @@ enum class LogChannel(
         viewerGroup = LogViewerGroup.MODULES,
         mirrorToRecord = true,
         visibleInViewer = true,
+        logTag = "会员"
     ),
     SPORTS(
         loggerName = "sports",
@@ -151,6 +158,7 @@ enum class LogChannel(
         viewerGroup = LogViewerGroup.MODULES,
         mirrorToRecord = true,
         visibleInViewer = true,
+        logTag = "运动"
     ),
     GREEN_FINANCE(
         loggerName = "green_finance",
@@ -161,6 +169,7 @@ enum class LogChannel(
         viewerGroup = LogViewerGroup.MODULES,
         mirrorToRecord = true,
         visibleInViewer = true,
+        logTag = "经营"
     ),
     SESAME_CREDIT(
         loggerName = "sesame_credit",
@@ -171,6 +180,7 @@ enum class LogChannel(
         viewerGroup = LogViewerGroup.MODULES,
         mirrorToRecord = true,
         visibleInViewer = true,
+        logTag = "芝麻粒"
     ),
     RUNTIME(
         loggerName = "runtime",
@@ -198,7 +208,7 @@ enum class LogChannel(
         description = "异常、失败、风控与错误堆栈日志",
         viewerGroup = LogViewerGroup.TECHNICAL,
         mirrorToRecord = true,
-        visibleInViewer = true,
+        visibleInViewer = true
     ),
     CAPTURE(
         loggerName = "capture",
@@ -222,14 +232,14 @@ enum class LogChannel(
 }
 
 object LogCatalog {
-    val channels: List<LogChannel> = LogChannel.values().toList()
+    val channels: List<LogChannel> = LogChannel.entries
 
     @JvmStatic
     fun loggerNames(): List<String> = channels.map { it.loggerName }.distinct()
 
     @JvmStatic
     fun viewerSections(): List<LogViewerSection> {
-        return LogViewerGroup.values().mapNotNull { group ->
+        return LogViewerGroup.entries.mapNotNull { group ->
             val groupChannels = channels.filter { it.visibleInViewer && it.viewerGroup == group }
             if (groupChannels.isEmpty()) {
                 null

--- a/app/src/main/java/io/github/aoguai/sesameag/util/Logback.kt
+++ b/app/src/main/java/io/github/aoguai/sesameag/util/Logback.kt
@@ -8,16 +8,21 @@ import ch.qos.logback.classic.LoggerContext
 import ch.qos.logback.classic.android.LogcatAppender
 import ch.qos.logback.classic.encoder.PatternLayoutEncoder
 import ch.qos.logback.classic.spi.ILoggingEvent
-import ch.qos.logback.core.FileAppender
+import ch.qos.logback.core.rolling.FixedWindowRollingPolicy
 import ch.qos.logback.core.rolling.RollingFileAppender
-import ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy
+import ch.qos.logback.core.rolling.SizeBasedTriggeringPolicy
 import ch.qos.logback.core.util.FileSize
 import io.github.aoguai.sesameag.data.General
 import org.slf4j.LoggerFactory
 import java.io.File
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
 
 object Logback {
     private var isFileInitialized = false
+    private var lastInitDate: String? = null
+    private var appContext: Context? = null
 
     /**
      * 阶段1：初始化 Logcat (保证控制台一定有日志)
@@ -59,7 +64,10 @@ object Logback {
      */
     @Synchronized
     fun initFileLogging(context: Context) {
-        if (isFileInitialized) return
+        this.appContext = context.applicationContext
+        val today = SimpleDateFormat("yyyy-MM-dd", Locale.getDefault()).format(Date())
+        // 如果已初始化且日期未变，则无需重复执行
+        if (isFileInitialized && lastInitDate == today) return
 
         val logDir = resolveLogDir(context)
         val isMainProcess = context.packageName == General.PACKAGE_NAME
@@ -67,15 +75,64 @@ object Logback {
         try {
             val lc = LoggerFactory.getILoggerFactory() as LoggerContext
 
+            if (isFileInitialized) {
+                lc.reset()
+                initLogcatOnly()
+            }
+
+            LogCatalog.loggerNames().forEach { logName ->
+                // 抓包日志不执行跨天物理归档，而是持续追加，直到触发大小滚动限制
+                if (logName != LogChannel.CAPTURE.loggerName) {
+                    performManualRolling(logDir, logName, today)
+                }
+            }
+
             // 为每个特定业务的 Logger 添加文件 Appender
             LogCatalog.loggerNames().forEach { logName ->
                 addFileAppender(lc, logName, logDir, isMainProcess)
             }
 
             isFileInitialized = true
-            Log.i("SesameLog", "File logging initialized at: $logDir (MainProcess: $isMainProcess)")
+            lastInitDate = today
+            Log.i("SesameLog", "File logging initialized for $today at: $logDir (MainProcess: $isMainProcess)")
         } catch (e: Exception) {
             Log.e("SesameLog", "Logback initFileLogging failed", e)
+        }
+    }
+
+    /**
+     * 供 Log.kt 每次写日志前调用，感应日期变化并自动重定向。
+     */
+    fun refreshIfCrossDay() {
+        appContext?.let { initFileLogging(it) }
+    }
+
+    /**
+     * 手动判断日期并滚动旧日志文件，解决多进程竞争导致的滚动逻辑混乱。
+     */
+    private fun performManualRolling(logDir: String, logName: String, today: String) {
+        val activeFile = File("$logDir$logName.log")
+        val bakDir = File(logDir, "bak")
+
+        // 1. 清理超过 3 天的历史归档
+        val threshold = System.currentTimeMillis() - 3 * 24 * 60 * 60 * 1000L
+        bakDir.listFiles { file ->
+            file.name.startsWith("$logName-") && file.name.endsWith(".log")
+        }?.forEach { file ->
+            if (file.lastModified() < threshold) {
+                file.delete()
+            }
+        }
+
+        // 2. 跨天滚动逻辑
+        if (!activeFile.exists()) return
+
+        val fileDay = SimpleDateFormat("yyyy-MM-dd", Locale.getDefault()).format(Date(activeFile.lastModified()))
+        if (today != fileDay) {
+            val target = File(bakDir, "$logName-$fileDay.log")
+            if (activeFile.renameTo(target)) {
+                Log.d("SesameLog", "Manual roll successful for $logName: $fileDay -> $today")
+            }
         }
     }
 
@@ -100,35 +157,29 @@ object Logback {
     }
 
     private fun addFileAppender(lc: LoggerContext, logName: String, logDir: String, isMainProcess: Boolean) {
-        // 主进程使用带滚动策略的 Appender，非主进程使用普通追加 Appender
-        val fileAppender = if (isMainProcess) RollingFileAppender<ILoggingEvent>() else FileAppender<ILoggingEvent>()
+        val fileAppender = RollingFileAppender<ILoggingEvent>()
 
         fileAppender.apply {
             context = lc
-            // 如果是 UI 进程，将其命名为内部 Appender，因为它会被 AsyncAppender 包装
-            name = if (isMainProcess) "FILE-$logName" else "INTERNAL-FILE-$logName"
+            name = if (isMainProcess) "FILE-HOOK-$logName" else "FILE-APP-$logName"
             file = "$logDir$logName.log"
             isAppend = true
 
-            if (this is RollingFileAppender) {
-                val rfa = this
-                // 只有主进程配置滚动策略
-                rollingPolicy = SizeAndTimeBasedRollingPolicy<ILoggingEvent>().apply {
-                    context = lc
-                    fileNamePattern = "${logDir}bak/$logName-%d{yyyy-MM-dd}.%i.log"
-                    setMaxFileSize(FileSize.valueOf("7MB"))
-                    setTotalSizeCap(FileSize.valueOf("32MB"))
-                    maxHistory = 3
-                    isCleanHistoryOnStart = true
-                    setParent(rfa)
-                    start()
-                }
-            } else {
-                // 非主进程开启 Prudent 模式，确保能感知到主进程随时可能触发的滚动（按天或按大小）
-                isPrudent = true
+            rollingPolicy = FixedWindowRollingPolicy().apply {
+                context = lc
+                fileNamePattern = "${logDir}bak/$logName.idx%i.log"
+                minIndex = 1
+                maxIndex = 3
+                setParent(fileAppender)
+                start()
             }
 
-            // 配置编码器
+            triggeringPolicy = SizeBasedTriggeringPolicy<ILoggingEvent>().apply {
+                context = lc
+                maxFileSize = FileSize.valueOf("7MB")
+                start()
+            }
+
             encoder = PatternLayoutEncoder().apply {
                 context = lc
                 pattern = "%d{dd日 HH:mm:ss.SS} %msg%n"
@@ -138,20 +189,15 @@ object Logback {
             start()
         }
 
-        val finalAppender = if (!isMainProcess) {
-            AsyncAppender().apply {
-                context = lc
-                name = "FILE-$logName"
-                queueSize = 256
-                discardingThreshold = 0
-                addAppender(fileAppender)
-                start()
-            }
-        } else {
-            fileAppender
+        val finalAppender = AsyncAppender().apply {
+            context = lc
+            name = "ASYNC-FILE-$logName"
+            queueSize = 512
+            discardingThreshold = 0
+            addAppender(fileAppender)
+            start()
         }
 
-        // 获取对应的 Logger 并添加 Appender
         lc.getLogger(logName).apply {
             level = Level.ALL
             isAdditive = true


### PR DESCRIPTION
1.我一直在一部安卓13的手机上使用，跨天日志的滚动正常，最近在一部安卓16上发现跨天时日志不会滚动，而是追加。因此修复了这个问题。
2.LogCatalog.kt中添加logTag参数，这样在Log.forest、Log.ocean这样调用时可以在record.log中直接添加原来的TAG参数，如“森林”、“海洋”。这样修改后Log.forest日志在写入record.log时会自动添加调用来源，可以更好确定日志的来源。参考：00:05:40.40[海洋]: 海洋奖励🌊[随机任务：逛一逛市集15s]# 1拼图
3.这样的修改后在调用Log.ocean时不要再次传入TAG参数，会导致在record.log中再次重复添加TAG的内容。但是目前代码中存在大量的重复添加TAG,不过也有大量没有添加TAG的调用，比较混乱。这样修改后后续模块类的Log.的调用统一不要添加TAG。后续在修改功能模块时可以顺便删除TAG。