### PR TITLE
AntFarm增加捐蛋排位赛功能支持

### DIFF
--- a/app/src/main/java/io/github/aoguai/sesameag/data/Status.kt
+++ b/app/src/main/java/io/github/aoguai/sesameag/data/Status.kt
@@ -58,7 +58,6 @@ class Status {
     var intFlagMap: MutableMap<String, Int> = HashMap()
 
     var dailyAnswerList: MutableSet<String> = HashSet()
-    var donationEggList: MutableSet<String> = HashSet()
     var useAccelerateToolCount: Int = 0
 
     /** 小鸡换装 */
@@ -471,15 +470,26 @@ class Status {
             save()
         }
 
+        /**
+         * 获取今日捐蛋总数
+         */
         @JvmStatic
-        fun canDonationEgg(uid: String?): Boolean {
-            return !INSTANCE.donationEggList.contains(uid)
+        fun getDonationCount(uid: String?): Int {
+            if (uid.isNullOrEmpty()) return 0
+            return getIntFlagToday(StatusFlags.FLAG_FARM_DONATION_COUNT + uid) ?: 0
         }
 
+        /**
+         * 更新捐蛋计数
+         * @param incremental true: 累加原有数值, false: 强制覆盖为新数值(用于服务器同步)
+         */
         @JvmStatic
-        fun donationEgg(uid: String?) {
-            if (!uid.isNullOrEmpty() && INSTANCE.donationEggList.add(uid)) {
-                save()
+        fun updateDonationCount(uid: String?, count: Int, incremental: Boolean = true) {
+            if (uid.isNullOrEmpty()) return
+            val finalCount = if (incremental) getDonationCount(uid) + count else count
+
+            if (finalCount != getDonationCount(uid)) {
+                setIntFlagToday(StatusFlags.FLAG_FARM_DONATION_COUNT + uid, finalCount)
             }
         }
 

--- a/app/src/main/java/io/github/aoguai/sesameag/data/StatusFlags.kt
+++ b/app/src/main/java/io/github/aoguai/sesameag/data/StatusFlags.kt
@@ -337,6 +337,10 @@ object StatusFlags {
     /** 庄园抽抽乐：限时任务今日已结束前缀 */
     const val FLAG_FARM_CHOUCHOULE_LIMITED_ENDED_PREFIX = "antFarm::chouchouleLimitedEnded::"
 
+    /** 庄园：捐蛋排位赛今日捐蛋总数*/
+    const val FLAG_FARM_DONATION_COUNT = "antFarm::donationCount|"
+
+
     /** 庄园家庭：今日签到已处理 */
     const val FLAG_FARM_FAMILY_SIGNED = "antFarm::familyDailySign"
 

--- a/app/src/main/java/io/github/aoguai/sesameag/task/antFarm/AntFarm.kt
+++ b/app/src/main/java/io/github/aoguai/sesameag/task/antFarm/AntFarm.kt
@@ -79,8 +79,8 @@ class AntFarm : ModelTask() {
     /**
      * 慈善评分
      */
-    private var benevolenceScore = 0.0
-    private var harvestBenevolenceScore = 0.0
+    internal var benevolenceScore = 0.0
+    internal var harvestBenevolenceScore = 0.0
 
     /**
      * 未领取的饲料奖励
@@ -215,6 +215,15 @@ class AntFarm : ModelTask() {
     internal var donation: BooleanModelField? = null
     internal var donationCount: ChoiceModelField? = null
 
+    internal var donationCompetition: BooleanModelField? = null
+    internal var receiveDonationCompetitionAward: BooleanModelField? = null
+    internal var harvestEggIfInsufficient: BooleanModelField? = null
+    internal var donationCompetitionTime: StringModelField? = null
+    internal var watchDonationRank: BooleanModelField? = null
+    internal var watchDonationAdvanceTime: IntegerModelField? = null
+    internal var watchDonationRefreshInterval: IntegerModelField? = null
+    internal var maxDailyDonationCompetitionCount: IntegerModelField? = null
+
     /**
      * 饲料任务
      */
@@ -273,7 +282,7 @@ class AntFarm : ModelTask() {
     internal var onlyQueryNewOrnaments: BooleanModelField? = null // 仅查询未兑换装扮
 
     internal var visitAnimal: BooleanModelField? = null
-    private var useSmartSchedulerManager: BooleanModelField? = null
+    internal var useSmartSchedulerManager: BooleanModelField? = null
     private var hasFence: Boolean = false       // 是否正在使用篱笆
     private var fenceCountDown: Int = 0
     // 雇佣NPC
@@ -603,6 +612,68 @@ class AntFarm : ModelTask() {
             ).withDesc("控制每日捐蛋次数。").also { donationCount = it })
         modelFields.addField(
             BooleanModelField(
+                "donationCompetition",
+                "捐蛋排行",
+                false
+            ).withDesc("执行庄园捐蛋排位赛，自动加入并按配置执行卡点反超逻辑。").also { donationCompetition = it })
+        modelFields.addField(
+            BooleanModelField(
+                "receiveDonationCompetitionAward",
+                "自动领取排位赛段位奖励",
+                true
+            ).withDesc("结算后自动领取已达成的段位奖励（如装扮币、食材）。").also {
+                receiveDonationCompetitionAward = it
+            })
+        modelFields.addField(
+            BooleanModelField(
+                "harvestEggIfInsufficient",
+                "剩余蛋数不足时收获蛋",
+                false
+            ).withDesc("在执行卡点捐蛋时，如果现有鸡蛋不足，且开启了此选项，则尝试先收取待收取的爱心蛋。").also {
+                harvestEggIfInsufficient = it
+            })
+        modelFields.addField(
+            StringModelField(
+                "donationCompetitionTime",
+                "单次蹲点捐蛋排行捐蛋时间",
+                "1958"
+            ).withDesc("设置执行卡点捐赠的时间：可以填具体时间如“1958”，或者填提前量如“2”（表示结束前2分钟）。").also {
+                donationCompetitionTime = it
+            })
+        modelFields.addField(
+            BooleanModelField(
+                "watchDonationRank",
+                "轮询蹲点排行榜",
+                false
+            ).withDesc("在排位赛结束前开启高频轮询，确保在最后时刻保持第一名。").also { watchDonationRank = it })
+        modelFields.addField(
+            IntegerModelField(
+                "watchDonationAdvanceTime",
+                "提前蹲点时间(分钟)",
+                2,
+                1,
+                10
+            ).withDesc("设置提前多久开始进入高频轮询状态。").also { watchDonationAdvanceTime = it })
+        modelFields.addField(
+            IntegerModelField(
+                "watchDonationRefreshInterval",
+                "蹲点刷新时间(秒)",
+                10,
+                1,
+                60
+            ).withDesc("高频轮询期间刷新排行榜的间隔时间。").also { watchDonationRefreshInterval = it })
+        modelFields.addField(
+            IntegerModelField(
+                "maxDailyDonationCompetitionCount",
+                "每日捐蛋总数",
+                10,
+                1,
+                20000
+            ).withDesc("设置排位赛每日允许捐赠的最大爱心蛋总数，达到上限后停止蹲点。防止排行榜过卷把蛋捐完了").also {
+                maxDailyDonationCompetitionCount = it
+            })
+        modelFields.addField(
+            BooleanModelField(
                 "useSpecialFood",
                 "使用特殊食品",
                 false
@@ -826,7 +897,8 @@ class AntFarm : ModelTask() {
     }
 
     internal fun shouldDonateEggNow(userId: String?): Boolean {
-        return donation?.value == true && Status.canDonationEgg(userId) && harvestBenevolenceScore >= 1
+        val limit = if (donationCount?.value == DonationCount.ALL) Int.MAX_VALUE else 1
+        return donation?.value == true && Status.getDonationCount(userId) < limit && harvestBenevolenceScore >= 1
     }
 
     internal fun preloadFarmTools() {
@@ -1818,8 +1890,7 @@ class AntFarm : ModelTask() {
                 }
                 lastDonationActivityIds = donatedActivityIds
                 if (isDonation && markStatusDone) {
-                    val userId = UserMap.currentUid
-                    Status.donationEgg(userId)
+                    Status.updateDonationCount(UserMap.currentUid, 1, incremental = true)
                 }
                 if (activityId == null) {
                     lastDonationNoMoreActivities = true
@@ -1836,22 +1907,34 @@ class AntFarm : ModelTask() {
         return false
     }
 
-    private fun performDonation(activityId: String?, activityName: String?): Boolean {
+    internal fun AntFarm.performDonation(
+        activityId: String?,
+        activityName: String?,
+        count: Int = 1,
+        historyCount: Int = 0
+    ): Boolean {
         try {
-            val s = AntFarmRpcCall.donation(activityId, 1)
+            val s = AntFarmRpcCall.donation(activityId, count)
             val donationResponse = JSONObject(s)
-            val memo = donationResponse.getString("memo")
             if (ResChecker.checkRes(TAG, donationResponse)) {
-                val donationDetails = donationResponse.getJSONObject("donation")
-                harvestBenevolenceScore = donationDetails.getDouble("harvestBenevolenceScore")
-                Log.farm("捐赠活动❤️[" + activityName + "]#累计捐赠" + donationDetails.getInt("donationTimesStat") + "次")
+                val donationDetails = donationResponse.optJSONObject("donation")
+                if (donationDetails != null) {
+                    harvestBenevolenceScore = donationDetails.optDouble("harvestBenevolenceScore")
+
+                    if (historyCount == 0) {
+                        Log.farm("捐赠活动❤️[$activityName]#捐赠了${count}颗蛋，首次捐赠该项目")
+                    } else {
+                        Log.farm("捐赠活动❤️[$activityName]#捐赠了${count}颗蛋，累计捐赠${historyCount + 1}次")
+                    }
+                } else {
+                    Log.farm("捐赠活动❤️[$activityName]#捐赠了${count}颗蛋")
+                }
                 return true
             } else {
-                Log.farm(memo)
-                Log.farm(s)
+                Log.farm("捐赠失败: ${donationResponse.optString("memo")}")
             }
         } catch (t: Throwable) {
-            Log.printStackTrace(t)
+            Log.printStackTrace(TAG, "performDonation err:", t)
         }
         return false
     }

--- a/app/src/main/java/io/github/aoguai/sesameag/task/antFarm/AntFarmDonationCompetition.kt
+++ b/app/src/main/java/io/github/aoguai/sesameag/task/antFarm/AntFarmDonationCompetition.kt
@@ -1,0 +1,338 @@
+package io.github.aoguai.sesameag.task.antFarm
+
+import io.github.aoguai.sesameag.data.Status
+import io.github.aoguai.sesameag.model.BaseModel
+import io.github.aoguai.sesameag.task.ModelTask
+import io.github.aoguai.sesameag.task.antFarm.AntFarm.Companion.TAG
+import io.github.aoguai.sesameag.util.Log
+import io.github.aoguai.sesameag.util.ResChecker
+import io.github.aoguai.sesameag.util.TimeUtil
+import io.github.aoguai.sesameag.util.maps.UserMap
+import kotlinx.coroutines.delay
+import org.json.JSONObject
+
+/**
+ * 捐蛋排位赛管理子模块：支持单次蹲点和轮询蹲点
+ */
+
+internal fun AntFarm.handleDonationCompetition() {
+    if (donationCompetition?.value != true) return
+
+    val endTimeStr = "2000"
+    val endCal = TimeUtil.getTodayCalendarByTimeStr(endTimeStr) ?: return
+    val now = System.currentTimeMillis()
+    val checkIntervalMs = BaseModel.checkInterval.value!!.toLong()
+    val creationWindowMs = 2 * checkIntervalMs
+    val creationStartTime = endCal.timeInMillis - creationWindowMs
+
+    if (now < creationStartTime) {
+        Log.record(TAG, "当前不在排位赛任务调度时间内")
+        return
+    }
+    if (now > endCal.timeInMillis) return
+
+    try {
+        val res = AntFarmRpcCall.enterDonationCompetitionRank()
+        val jo = JSONObject(res)
+        if (!ResChecker.checkRes(TAG, jo)) {
+            Log.record(TAG, "进入捐蛋排位赛失败: ${jo.optString("memo")}")
+            return
+        }
+
+        if (receiveDonationCompetitionAward?.value == true) {
+            val rankInfo = jo.optJSONObject("donationRankHomeInfo")
+            if (rankInfo?.optBoolean("hasAward") == true) {
+                receiveCompetitionAwards()
+            }
+        }
+
+        scheduleDonationCompetitionTask(endCal.timeInMillis)
+
+    } catch (e: Exception) {
+        Log.printStackTrace(TAG, "handleDonationCompetition err:", e)
+    }
+}
+
+/**
+ * 遍历奖励列表并领取
+ */
+private fun receiveCompetitionAwards() {
+    try {
+        val res = AntFarmRpcCall.enterCompetitionAwardPage()
+        val jo = JSONObject(res)
+        if (!ResChecker.checkRes(TAG, jo)) return
+
+        val userLevelInfo = jo.optJSONObject("userDonationLevelInfo") ?: return
+        val currentLevelId = userLevelInfo.optInt("levelId")
+        val currentLevelName = userLevelInfo.optString("levelName")
+        val lightStars = userLevelInfo.optInt("levelLightStarNum", 0)
+
+        val awardList = jo.optJSONArray("levelAwardInfoList") ?: return
+
+        var highestLevelName = "未知"
+        var starsToHighest = 0
+        var nextLevelName = "已达顶峰"
+
+        for (i in 0 until awardList.length()) {
+            val levelItem = awardList.getJSONObject(i)
+            val lId = levelItem.optInt("levelId")
+
+            if (i == 0) highestLevelName = levelItem.optString("levelName")
+
+            if (lId == currentLevelId + 1) {
+                nextLevelName = levelItem.optString("levelName")
+            }
+
+            if (lId >= currentLevelId) {
+                val upNum = levelItem.optInt("levelStarUpNum")
+                if (upNum < 10000) {
+                    starsToHighest += upNum
+                }
+            }
+        }
+
+        val starsToNext = userLevelInfo.optInt("levelStarUpNum") - lightStars
+        starsToHighest -= lightStars
+
+        val endTime = jo.optJSONObject("donationCompetitionActivityConf")?.optLong("endTime") ?: 0L
+
+        Log.record(TAG, "--- 🏆 排位赛赛季简报 ---")
+        Log.record(TAG, "📅 赛季结束：${TimeUtil.getCommonDate(endTime)}")
+        Log.record(TAG, "📈 当前段位：$currentLevelName")
+        Log.record(TAG, "🏹 下一段位：$nextLevelName (差 ${starsToNext}🌟)")
+        Log.record(TAG, "👑 最高段位：$highestLevelName (总差距 ${starsToHighest}🌟)")
+        Log.record(TAG, "------------------------")
+
+        for (i in 0 until awardList.length()) {
+            val award = awardList.getJSONObject(i)
+            if (award.optString("status") == "unreceived") {
+                val rightsId = award.getString("rightsId")
+                val levelName = award.optString("levelName", "未知段位")
+
+                Log.record(TAG, "发现可领取排位奖励：$levelName")
+                val receiveRes = AntFarmRpcCall.receiveDonationLevelReward(rightsId)
+                val receiveJo = JSONObject(receiveRes)
+
+                if (ResChecker.checkRes(TAG, receiveJo)) {
+                    Log.record(TAG, "🎉 成功领取 $levelName 段位奖励")
+                }
+            }
+        }
+    } catch (e: Exception) {
+        Log.printStackTrace(TAG, "receiveCompetitionAwards err:", e)
+    }
+}
+
+/**
+ * 统一调度蹲点任务
+ * 逻辑：轮询蹲点开启时忽略单次蹲点，否则按单次蹲点时间运行
+ */
+private fun AntFarm.scheduleDonationCompetitionTask(endTimeMs: Long) {
+    val taskId = "DR|$ownerFarmId"
+    if (hasChildTask(taskId)) return
+
+    val uid = UserMap.currentUid
+    val maxDonation = maxDailyDonationCompetitionCount?.value ?: 10
+    val currentDonated = Status.getDonationCount(uid)
+    if (currentDonated >= maxDonation) {
+        Log.record(TAG, "今日排位赛捐蛋数($currentDonated)已达上限($maxDonation)，跳过任务调度")
+        return
+    }
+
+    val isPollingMode = watchDonationRank?.value == true
+    val execTime: Long
+
+    if (isPollingMode) {
+        val advanceMin = watchDonationAdvanceTime?.value ?: 2
+        execTime = endTimeMs - advanceMin * 60 * 1000L
+    } else {
+        val timeCfg = donationCompetitionTime?.value ?: "1958"
+        execTime = if (timeCfg.length >= 3) {
+            TimeUtil.getTodayCalendarByTimeStr(timeCfg)?.timeInMillis ?: 0L
+        } else {
+            val min = timeCfg.toIntOrNull() ?: 2
+            endTimeMs - min * 60 * 1000L
+        }
+    }
+
+    val now = System.currentTimeMillis()
+    if (execTime <= now) return
+
+    val modeName = if (isPollingMode) "轮询蹲点" else "单次蹲点"
+
+    val task = ModelTask.ChildModelTask(
+        id = taskId,
+        group = "DR",
+        suspendRunnable = {
+            if (isPollingMode) {
+                runDonationRankWatchLoop(endTimeMs)
+            } else {
+                Log.record(TAG, "🔔 执行单次排位赛捐赠检查")
+                val uid = UserMap.currentUid ?: return@ChildModelTask
+                val donationsMadeToday = Status.getDonationCount(uid)
+                val maxDonation = maxDailyDonationCompetitionCount?.value ?: 10
+                if (donationsMadeToday < maxDonation) {
+                    checkRankAndDonate(maxDonation - donationsMadeToday)
+                }
+            }
+        },
+        execTime = execTime,
+        useSmartScheduler = useSmartSchedulerManager?.value == true
+    )
+
+    addChildTask(task)
+    Log.record(TAG, "✅ 已创建${modeName}任务，执行时间: ${TimeUtil.getCommonDate(execTime)}")
+}
+
+private suspend fun AntFarm.runDonationRankWatchLoop(endTimeMs: Long) {
+    val refreshSec = watchDonationRefreshInterval?.value ?: 10
+    Log.record(TAG, "🚀 开始排位赛轮询蹲点，间隔 ${refreshSec}s")
+
+    while (System.currentTimeMillis() < endTimeMs) {
+        val uid = UserMap.currentUid ?: break
+        val currentDonated = Status.getDonationCount(uid)
+        val maxDonation = maxDailyDonationCompetitionCount?.value ?: 10
+
+        if (currentDonated >= maxDonation) {
+            Log.record(TAG, "已达到每日捐蛋排位限额($maxDonation)，结束蹲点。")
+            break
+        }
+
+        checkRankAndDonate(maxDonation - currentDonated)
+
+        delay(refreshSec * 1000L)
+    }
+    Log.record(TAG, "🏁 轮询蹲点结束")
+}
+
+private fun AntFarm.checkRankAndDonate(remainingQuota: Int): Boolean {
+    try {
+        val myUid = UserMap.currentUid ?: return false
+        val res = AntFarmRpcCall.enterDonationCompetitionRank()
+        val jo = JSONObject(res)
+        if (ResChecker.checkRes(TAG, jo)) {
+            syncAnimalStatus(ownerFarmId)
+
+            val rankInfo = jo.optJSONObject("donationRankHomeInfo") ?: return false
+            val rankList = rankInfo.optJSONArray("userDonationRankList") ?: return false
+
+            if (rankList.length() > 0) {
+                var myData: JSONObject? = null
+                for (i in 0 until rankList.length()) {
+                    val user = rankList.getJSONObject(i)
+                    if (user.getString("userId") == myUid) {
+                        myData = user
+                        break
+                    }
+                }
+
+                if (myData == null) {
+                    Log.record(TAG, "未在排行榜中找到个人数据，可能尚未初始化")
+                    return false
+                }
+
+                val serverDonationCount = myData.getInt("donationNum")
+                val localDonationCount = Status.getDonationCount(myUid)
+                if (serverDonationCount != localDonationCount) {
+                    Status.updateDonationCount(myUid, serverDonationCount, incremental = false)
+                }
+
+                val myRank = myData.getInt("rankOrder")
+                val myStars = myData.optInt("rewardStarNum", 0)
+
+                // 如果已经是第一名，根据策略不做处理
+                if (myRank == 1) {
+                    Log.record(TAG, "当前已是第一名(${serverDonationCount}蛋)，无需捐赠")
+                    return false
+                }
+
+                // 寻找能提升星星奖励的目标
+                var targetRank = -1
+                var targetEggsNeeded = -1
+                var targetStarsExpected = myStars
+
+                // 从第一名开始向下遍历，寻找配额内能达到的最高星级
+                for (i in 0 until rankList.length()) {
+                    val other = rankList.getJSONObject(i)
+                    val oRank = other.getInt("rankOrder")
+                    if (oRank >= myRank) break // 只看比我名次高的
+
+                    val oStars = other.optInt("rewardStarNum", 0)
+                    val oDonation = other.getInt("donationNum")
+
+                    // 只有当该名次的奖励高于我当前的奖励时才考虑
+                    if (oStars > myStars) {
+                        val eggsNeeded = oDonation - serverDonationCount + 1
+                        if (eggsNeeded <= remainingQuota) {
+                            // 如果这个名次的星星比之前发现的目标更高，或者星星一样但更省蛋
+                            if (oStars > targetStarsExpected) {
+                                targetStarsExpected = oStars
+                                targetEggsNeeded = eggsNeeded
+                                targetRank = oRank
+                            } else if (oStars == targetStarsExpected) {
+                                // 同样多的星星，选择更省蛋的名次
+                                if (targetEggsNeeded == -1 || eggsNeeded < targetEggsNeeded) {
+                                    targetEggsNeeded = eggsNeeded
+                                    targetRank = oRank
+                                }
+                            }
+                        }
+                    }
+                }
+
+                if (targetRank != -1 && targetEggsNeeded > 0) {
+                    Log.record(TAG, "精明捐赠：当前奖励${myStars}星，目标排名${targetRank}(奖励${targetStarsExpected}星)，需反超${targetEggsNeeded}个蛋")
+                    if (donateForCompetition(targetEggsNeeded)) {
+                        // 捐赠成功后立即手动更新一次本地计数
+                        Status.updateDonationCount(myUid, targetEggsNeeded, incremental = true)
+                        return true
+                    }
+                } else {
+                    Log.record(TAG, "评估结论：剩余配额(${remainingQuota})不足以提升星星奖励，放弃捐赠")
+                }
+            }
+        }
+    } catch (e: Exception) {
+        Log.printStackTrace(TAG, "checkRankAndDonate err:", e)
+    }
+    return false
+}
+
+private fun AntFarm.donateForCompetition(count: Int): Boolean {
+    try {
+        if (harvestBenevolenceScore < count) {
+            if (harvestEggIfInsufficient?.value == true && benevolenceScore >= 1.0) {
+                Log.record(TAG, "排位反超蛋数不足(当前:$harvestBenevolenceScore)，发现有待收取蛋($benevolenceScore)，尝试先收获...")
+                harvestProduce(ownerFarmId)
+            }
+
+            if (harvestBenevolenceScore < count) {
+                Log.record(TAG, "排位反超🥚[鸡蛋不足(当前:$harvestBenevolenceScore)，需要:$count，跳过本次捐赠]")
+                return false
+            }
+        }
+
+        val s = AntFarmRpcCall.listActivityInfo()
+        val jo = JSONObject(s)
+        if (!ResChecker.checkRes(TAG, jo)) return false
+
+        val jaActivityInfos = jo.optJSONArray("activityInfos") ?: return false
+        if (jaActivityInfos.length() == 0) return false
+
+        // 寻找第一个未满的项目进行捐赠
+        for (i in 0 until jaActivityInfos.length()) {
+            val projectJo = jaActivityInfos.getJSONObject(i)
+            val donationTotal = projectJo.optDouble("donationTotal", 0.0)
+            val donationLimit = projectJo.optDouble("donationLimit", 0.0)
+            if (donationTotal >= donationLimit) continue
+
+            val activityId = projectJo.getString("activityId")
+            val activityName = projectJo.optString("projectName", activityId)
+
+            return performDonation(activityId, activityName, count)
+        }
+    } catch (e: Exception) {
+        Log.printStackTrace(TAG, "donateForCompetition err:", e)
+    }
+    return false
+}

--- a/app/src/main/java/io/github/aoguai/sesameag/task/antFarm/AntFarmRpcCall.kt
+++ b/app/src/main/java/io/github/aoguai/sesameag/task/antFarm/AntFarmRpcCall.kt
@@ -1592,5 +1592,51 @@ object AntFarmRpcCall {
         }
         return requestString("com.alipay.antfarm.syncOrnamentCoin", "[$args]")
     }
+
+
+    @JvmStatic
+    fun queryCompetitionEntranceInfo(): String {
+        val args = JSONObject().apply {
+            put("requestType", "NORMAL")
+            put("sceneCode", "ANTFARM")
+            put("source", "H5")
+            put("version", VERSION)
+        }
+        return RequestManager.requestString("com.alipay.antfarm.queryCompetitionEntranceInfo", "[$args]")
+    }
+
+    @JvmStatic
+    fun enterDonationCompetitionRank(): String {
+        val args = JSONObject().apply {
+            put("requestType", "NORMAL")
+            put("sceneCode", "ANTFARM")
+            put("source", "H5")
+            put("version", VERSION)
+        }
+        return RequestManager.requestString("com.alipay.antfarm.enterDonationCompetitionRank", "[$args]")
+    }
+
+    @JvmStatic
+    fun enterCompetitionAwardPage(): String {
+        val args = JSONObject().apply {
+            put("requestType", "NORMAL")
+            put("sceneCode", "ANTFARM")
+            put("source", "H5")
+            put("version", VERSION)
+        }
+        return RequestManager.requestString("com.alipay.antfarm.enterCompetitionAwardPage", "[$args]")
+    }
+
+    @JvmStatic
+    fun receiveDonationLevelReward(rightsId: String?): String {
+        val args = JSONObject().apply {
+            put("requestType", "NORMAL")
+            put("rightsId", rightsId ?: "")
+            put("sceneCode", "ANTFARM")
+            put("source", "H5")
+            put("version", VERSION)
+        }
+        return RequestManager.requestString("com.alipay.antfarm.receiveDonationLevelReward", "[$args]")
+    }
 }
 

--- a/app/src/main/java/io/github/aoguai/sesameag/task/antFarm/AntFarmWorkflow.kt
+++ b/app/src/main/java/io/github/aoguai/sesameag/task/antFarm/AntFarmWorkflow.kt
@@ -97,7 +97,7 @@ internal suspend fun AntFarm.runFarmTaskWorkflow(tc: TimeCounter, userId: String
             familyDonationActivityIds = lastDonationActivityIds
         }
         if (singleDonationMode && familyDailyDonateResult.consumedDonation) {
-            Status.donationEgg(userId)
+            Status.updateDonationCount(userId, 1, incremental = true)
             skipPublicDonationThisRun = true
         }
         if (familyDailyDonateResult == AntFarmFamily.DailyDonateTaskResult.DONATED_CONFIRMED) {
@@ -131,7 +131,7 @@ internal suspend fun AntFarm.runFarmTaskWorkflow(tc: TimeCounter, userId: String
             Log.farm("公益捐蛋未完成，保留后续重试")
         }
     }
-    if (familyDailyDonateResult.consumedDonation && !userId.isNullOrBlank() && Status.canDonationEgg(userId)) {
+    if (familyDailyDonateResult.consumedDonation && !userId.isNullOrBlank() && Status.getDonationCount(userId) < 1) {
         val noFurtherDonationNeeded =
             if (!familyDailyDonateResult.shouldMarkDonationDone) {
                 false
@@ -141,7 +141,7 @@ internal suspend fun AntFarm.runFarmTaskWorkflow(tc: TimeCounter, userId: String
                     (attemptedPublicDonation && lastDonationNoMoreActivities)
             }
         if (noFurtherDonationNeeded) {
-            Status.donationEgg(userId)
+            Status.updateDonationCount(userId, 1, incremental = true)
         }
     }
 
@@ -149,6 +149,8 @@ internal suspend fun AntFarm.runFarmTaskWorkflow(tc: TimeCounter, userId: String
         receiveFarmAwards()
         tc.countDebug("收取饲料奖励")
     }
+
+    handleDonationCompetition()
 
     return pendingFarmTaskFinalization
 }


### PR DESCRIPTION
1.原方法的handleDonation及其设置选项"随机一次", "随机多次"非常有迷惑性，可以改成arrayOf("当日列表中的一个项目", "当日列表中全部可捐项目", "当日列表中所有未捐项目")这样通俗易懂的选项，并且单次捐赠可以直接选择捐赠几个蛋，在原方法中直接写死为捐1个，并且提供迷惑的选项。但是你在修改时提供了家庭捐赠等等代码，我不便修改，因此原代码中的捐蛋相关部分尽量没有修改。
2.代码需进步一测试。后续可能需要修改
3.针对在家庭任务中捐蛋部分的逻辑是否有额外收益？因为我似乎没有发现有什么区别，同理还有顶梁柱任务让亲密值最低的人执行是否有额外收益？
4.捐蛋排位赛功能自定义单次蹲点或轮询蹲点，卡点捐蛋到榜一（有限制条件），轮询蹲点默认10秒刷新一次排行榜发现名次变动会补捐蛋。