### PR TITLE
AntFarm捐蛋排行榜增加 20:00 后的中止判断

### DIFF
--- a/app/src/main/java/io/github/aoguai/sesameag/task/antFarm/AntFarmDonationCompetition.kt
+++ b/app/src/main/java/io/github/aoguai/sesameag/task/antFarm/AntFarmDonationCompetition.kt
@@ -735,6 +735,12 @@ private fun AntFarm.donateForCompetition(count: Int): Boolean {
             }
         }
 
+        val endCal = TimeUtil.getTodayCalendarByTimeStr("2000")
+        if (endCal != null && System.currentTimeMillis() >= endCal.timeInMillis) {
+            Log.record(TAG, "⏰ 捐赠中止：当前已过 20:00 结算时间，放弃捐赠")
+            return false
+        }
+
         val s = AntFarmRpcCall.listActivityInfo()
         val jo = JSONObject(s)
         if (!ResChecker.checkRes(TAG, jo)) return false


### PR DESCRIPTION
- 如果实际捐赠时因为网络等延迟超过 20:00 结算时间，则自动中止并退出这次捐赠。