### PR TITLE
AntFarm捐蛋排位赛逻辑优化与配置增强

### DIFF
--- a/app/src/main/java/io/github/aoguai/sesameag/task/antFarm/AntFarm.kt
+++ b/app/src/main/java/io/github/aoguai/sesameag/task/antFarm/AntFarm.kt
@@ -239,9 +239,11 @@ class AntFarm : ModelTask() {
     internal var donationCompetitionSpecialFoodCount: IntegerModelField? = null
     internal var stableDonationCompetitionAnytimeCheck: BooleanModelField? = null
     internal var donationCompetitionTime: StringModelField? = null
+    internal var donationCompetitionOvertakeAmount: IntegerModelField? = null
     internal var watchDonationRank: BooleanModelField? = null
     internal var watchDonationAdvanceTime: IntegerModelField? = null
     internal var watchDonationRefreshInterval: IntegerModelField? = null
+    internal var watchDonationLastRefreshSecondsBeforeEnd: IntegerModelField? = null
     internal var maxDailyDonationCompetitionCount: IntegerModelField? = null
 
     /**
@@ -716,6 +718,16 @@ class AntFarm : ModelTask() {
                 donationCompetitionTime = it
             })
         modelFields.addField(
+            IntegerModelField(
+                "donationCompetitionOvertakeAmount",
+                "捐蛋排位赛 | 超过前一名的捐蛋数",
+                1,
+                1,
+                10000
+            ).withDesc("在尝试反超前一名时，比对方多捐赠的爱心蛋数量。").also {
+                donationCompetitionOvertakeAmount = it
+            })
+        modelFields.addField(
             BooleanModelField(
                 "watchDonationRank",
                 "捐蛋排位赛 | 轮询蹲点",
@@ -737,6 +749,16 @@ class AntFarm : ModelTask() {
                 1,
                 60
             ).withDesc("高频轮询期间刷新排行榜的间隔时间。").also { watchDonationRefreshInterval = it })
+        modelFields.addField(
+            IntegerModelField(
+                "watchDonationLastRefreshSecondsBeforeEnd",
+                "捐蛋排位赛 | 轮询最后刷新距结束(秒)",
+                2,
+                0,
+                10
+            ).withDesc("控制轮询蹲点在结束前多少秒执行最后一次强制刷新，小于2秒意义不大，因为网络请求慢。").also {
+                watchDonationLastRefreshSecondsBeforeEnd = it
+            })
         modelFields.addField(
             BooleanModelField(
                 "useSpecialFood",

--- a/app/src/main/java/io/github/aoguai/sesameag/task/antFarm/AntFarmDonationCompetition.kt
+++ b/app/src/main/java/io/github/aoguai/sesameag/task/antFarm/AntFarmDonationCompetition.kt
@@ -374,7 +374,8 @@ private fun selectAggressiveDonationTarget(
     myRank: Int,
     myStars: Int,
     serverDonationTotal: Int,
-    effectiveRemainingQuota: Int
+    effectiveRemainingQuota: Int,
+    overtakeAmount: Int
 ): DonationRankTarget? {
     var target: DonationRankTarget? = null
 
@@ -386,7 +387,7 @@ private fun selectAggressiveDonationTarget(
         val otherStars = other.optInt("rewardStarNum", 0)
         if (otherStars <= myStars) continue
 
-        val eggsNeeded = other.getInt("donationNum") - serverDonationTotal + 1
+        val eggsNeeded = other.getInt("donationNum") - serverDonationTotal + overtakeAmount
         if (eggsNeeded <= 0 || eggsNeeded > effectiveRemainingQuota) continue
 
         val currentTarget = target
@@ -406,7 +407,8 @@ private fun selectStableDonationTarget(
     myStars: Int,
     serverDonationTotal: Int,
     effectiveRemainingQuota: Int,
-    requiredStarsToday: Int
+    requiredStarsToday: Int,
+    overtakeAmount: Int
 ): DonationRankTarget? {
     var target: DonationRankTarget? = null
 
@@ -418,7 +420,7 @@ private fun selectStableDonationTarget(
         val otherStars = other.optInt("rewardStarNum", 0)
         if (otherStars <= myStars || otherStars < requiredStarsToday) continue
 
-        val eggsNeeded = other.getInt("donationNum") - serverDonationTotal + 1
+        val eggsNeeded = other.getInt("donationNum") - serverDonationTotal + overtakeAmount
         if (eggsNeeded <= 0 || eggsNeeded > effectiveRemainingQuota) continue
 
         val currentTarget = target
@@ -520,6 +522,12 @@ private fun AntFarm.scheduleDonationCompetitionTask(endTimeMs: Long) {
                     checkRankAndDonate(maxDonation - donationsMadeToday)
                 }
             }
+            val reportTime = endTimeMs + 10000L
+            val waitToReport = reportTime - System.currentTimeMillis()
+            if (waitToReport > 0) {
+                Log.record(TAG, "📊 等待结算完成，等待10s获取战报统计")
+                delay(waitToReport)
+            }
             printDonationReport()
         },
         execTime = finalExecTime,
@@ -536,9 +544,15 @@ private fun AntFarm.scheduleDonationCompetitionTask(endTimeMs: Long) {
 
 private suspend fun AntFarm.runDonationRankWatchLoop(endTimeMs: Long) {
     val refreshSec = watchDonationRefreshInterval?.value ?: 10
-    Log.record(TAG, "🚀 开始排位赛轮询蹲点，间隔 ${refreshSec}s")
+    val lastGapSec = watchDonationLastRefreshSecondsBeforeEnd?.value ?: 2
+    val lastRefreshTime = endTimeMs - lastGapSec * 1000L
 
-    while (System.currentTimeMillis() < endTimeMs) {
+    Log.record(TAG, "🚀 开始排位赛轮询蹲点，间隔 ${refreshSec}s，最后一次刷新时间点：${TimeUtil.getFormatTime(lastRefreshTime, "HH:mm:ss")}")
+
+    while (true) {
+        val now = System.currentTimeMillis()
+        if (now >= endTimeMs) break
+
         val uid = UserMap.currentUid ?: break
         val currentDonated = Status.getDailyDonationTotal(uid)
         val maxDonation = maxDailyDonationCompetitionCount?.value ?: -1
@@ -554,7 +568,31 @@ private suspend fun AntFarm.runDonationRankWatchLoop(endTimeMs: Long) {
             checkRankAndDonate(maxDonation - currentDonated)
         }
 
-        delay(refreshSec * 1000L)
+        val afterDonateNow = System.currentTimeMillis()
+        if (afterDonateNow >= endTimeMs) break
+
+        val nextNormalRefresh = afterDonateNow + refreshSec * 1000L
+
+        if (nextNormalRefresh >= lastRefreshTime) {
+            val waitToFinal = lastRefreshTime - System.currentTimeMillis()
+            if (waitToFinal > 0) {
+                Log.record(TAG, "⏳ 等待最后一次刷新 (距离结束 $lastGapSec 秒)")
+                delay(waitToFinal)
+
+                if (System.currentTimeMillis() < endTimeMs) {
+                    Log.record(TAG, "⚡ 执行最后一次刷新")
+                    val finalCurrentDonated = Status.getDailyDonationTotal(uid)
+                    if (maxDonation < 0) {
+                        checkRankAndDonate(Int.MAX_VALUE)
+                    } else if (finalCurrentDonated < maxDonation) {
+                        checkRankAndDonate(maxDonation - finalCurrentDonated)
+                    }
+                }
+            }
+            break // 执行完收官动作后退出循环
+        } else {
+            delay(refreshSec * 1000L)
+        }
     }
     Log.record(TAG, "🏁 轮询蹲点结束")
 }
@@ -607,6 +645,7 @@ private fun AntFarm.checkRankAndDonate(
 
                 val myRank = myData.getInt("rankOrder")
                 val myStars = myData.optInt("rewardStarNum", 0)
+                val overtakeAmount = donationCompetitionOvertakeAmount?.value ?: 1
 
                 // 如果已经是第一名，根据策略不做处理
                 if (myRank == 1) {
@@ -643,7 +682,8 @@ private fun AntFarm.checkRankAndDonate(
                         myStars,
                         serverDonationTotal,
                         effectiveRemainingQuota,
-                        stablePlan.requiredStarsToday
+                        stablePlan.requiredStarsToday,
+                        overtakeAmount
                     ) ?: run {
                         if (!allowAggressiveFallback) {
                             Log.record(
@@ -661,7 +701,8 @@ private fun AntFarm.checkRankAndDonate(
                             myRank,
                             myStars,
                             serverDonationTotal,
-                            effectiveRemainingQuota
+                            effectiveRemainingQuota,
+                            overtakeAmount
                         )
                     }
                 } else {
@@ -685,7 +726,8 @@ private fun AntFarm.checkRankAndDonate(
                         myRank,
                         myStars,
                         serverDonationTotal,
-                        effectiveRemainingQuota
+                        effectiveRemainingQuota,
+                        overtakeAmount
                     )
                 }
 


### PR DESCRIPTION
- 新增“反超前一名捐赠数”配置，支持自定义反超目标时的额外捐赠数量。
- 新增“轮询最后刷新距结束秒数”配置，用于控制倒计时结束前的最后一次刷新时机。
- 优化排位赛轮询监听逻辑，确保在比赛结束前的指定时间点执行精准刷新与冲刺。
- 在比赛结束后增加 10 秒延迟再读取战报，以确保结算统计完成，提高数据准确性。
卷吧，用力卷，直接反超他100个，看他怎么搞