### PR TITLE
去除森林道具检查中的else分支

### DIFF
--- a/app/src/main/java/io/github/aoguai/sesameag/task/antForest/AntForest.kt
+++ b/app/src/main/java/io/github/aoguai/sesameag/task/antForest/AntForest.kt
@@ -3753,9 +3753,6 @@ class AntForest : ModelTask(), EnergyCollectCallback {
                             }
                         }
                     }
-                    else -> {
-                        if (!silent) Log.forest("跳过非目标道具:$userUsingProp")
-                    }
                 }
             }
         } catch (th: Throwable) {


### PR DESCRIPTION
非目标道具检查的日志没有意义，直接去除，减少刷屏