### PR TITLE
分离DataStore中和用户相关的数据到UserDataStore.kt中

### DIFF
--- a/app/src/main/java/io/github/aoguai/sesameag/task/antFarm/AntFarmDonationCompetition.kt
+++ b/app/src/main/java/io/github/aoguai/sesameag/task/antFarm/AntFarmDonationCompetition.kt
@@ -10,6 +10,7 @@ import io.github.aoguai.sesameag.util.DataStore
 import io.github.aoguai.sesameag.util.Log
 import io.github.aoguai.sesameag.util.ResChecker
 import io.github.aoguai.sesameag.util.TimeUtil
+import io.github.aoguai.sesameag.util.UserDataStoreManager
 import io.github.aoguai.sesameag.util.maps.UserMap
 import kotlinx.coroutines.delay
 import org.json.JSONArray
@@ -38,7 +39,8 @@ private data class DonationAwardSnapshot(
     val currentLevelName: String,
     val starsToHighest: Int,
     val totalStarsToHighest: Int,
-    val allRewardsReceived: Boolean
+    val allRewardsReceived: Boolean,
+    val hasUnclaimedAwards: Boolean = false
 )
 
 private data class StableDonationPlan(
@@ -60,6 +62,11 @@ private data class DonationRankTarget(
 
 internal fun AntFarm.handleDonationCompetition() {
     if (donationCompetition?.value != true) return
+
+    val store = UserDataStoreManager.getCurrentInstance()
+    if (store?.hasPersistentFlag("AntFarm::DonationCompetitionFinished") == true) {
+        return
+    }
 
     if (receiveDonationCompetitionAward?.value == true &&
         !Status.hasFlagToday(StatusFlags.FLAG_FARM_DONATION_COMPETITION_AWARD_RECEIVED)
@@ -109,9 +116,17 @@ internal fun AntFarm.handleDonationCompetition() {
             return
         }
 
-        if (receiveDonationCompetitionAward?.value == true) {
-            val snapshot = queryDonationAwardSnapshot()
-            if (snapshot != null && snapshot.starsToHighest > 0) {
+        val snapshot = queryDonationAwardSnapshot()
+        if (snapshot != null) {
+            if (snapshot.starsToHighest <= 0 && !snapshot.hasUnclaimedAwards) {
+                Log.record(TAG, "🏆 已到达最高段位并拿满奖励，本赛季不再参与排名竞争")
+                if (seasonEndTime > now) {
+                    Log.record(TAG, "📅 已设置持久化拦截，本赛季结束前将不再运行捐蛋排位赛")
+                    store?.setPersistentFlag("AntFarm::DonationCompetitionFinished", seasonEndTime)
+                }
+                return
+            }
+            if (receiveDonationCompetitionAward?.value == true && snapshot.starsToHighest > 0) {
                 checkAndClaimProgressAwards(jo, snapshot.starsToHighest)
             }
         }
@@ -233,8 +248,9 @@ private fun AntFarm.isStableDonationCompetitionMode(): Boolean {
 }
 
 private fun AntFarm.hasCompletedStableDonationCompetition(): Boolean {
+    if (UserDataStoreManager.getCurrentInstance()?.hasPersistentFlag("AntFarm::DonationCompetitionFinished") == true) return true
     val snapshot = queryDonationAwardSnapshot() ?: return false
-    if (!snapshot.allRewardsReceived || snapshot.starsToHighest > 0) return false
+    if (snapshot.hasUnclaimedAwards || snapshot.starsToHighest > 0) return false
     Log.record(TAG, "排位赛稳定模式：最高段位奖励已领取完成，跳过排位赛处理")
     return true
 }
@@ -271,15 +287,20 @@ private fun parseDonationAwardSnapshot(jo: JSONObject): DonationAwardSnapshot? {
     var totalStarsToHighest = 0
     var validAwardCount = 0
     var receivedAwardCount = 0
+    var hasUnclaimed = false
 
     for (i in 0 until awardList.length()) {
         val levelItem = awardList.optJSONObject(i) ?: continue
         val upNum = levelItem.optInt("levelStarUpNum", 0)
+        val status = levelItem.optString("status")
         if (levelItem.optString("rightsId").isNotBlank()) {
             validAwardCount++
-            if (levelItem.optString("status").equals("received", ignoreCase = true)) {
+            if (status.equals("received", ignoreCase = true)) {
                 receivedAwardCount++
             }
+        }
+        if (status.equals("unreceived", ignoreCase = true)) {
+            hasUnclaimed = true
         }
         if (upNum >= TOP_LEVEL_STAR_SENTINEL) continue
 
@@ -298,7 +319,8 @@ private fun parseDonationAwardSnapshot(jo: JSONObject): DonationAwardSnapshot? {
         currentLevelName = currentLevelName,
         starsToHighest = starsToHighest,
         totalStarsToHighest = totalStarsToHighest,
-        allRewardsReceived = validAwardCount > 0 && receivedAwardCount == validAwardCount
+        allRewardsReceived = validAwardCount > 0 && receivedAwardCount == validAwardCount,
+        hasUnclaimedAwards = hasUnclaimed
     )
 }
 

--- a/app/src/main/java/io/github/aoguai/sesameag/task/antForest/EnergyWaitingPersistence.kt
+++ b/app/src/main/java/io/github/aoguai/sesameag/task/antForest/EnergyWaitingPersistence.kt
@@ -3,10 +3,11 @@ package io.github.aoguai.sesameag.task.antForest
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import com.fasterxml.jackson.core.type.TypeReference
 import io.github.aoguai.sesameag.hook.AccountSessionCoordinator
-import io.github.aoguai.sesameag.util.DataStore
 import io.github.aoguai.sesameag.util.FriendGuard
 import io.github.aoguai.sesameag.util.Log
 import io.github.aoguai.sesameag.util.TimeUtil
+import io.github.aoguai.sesameag.util.UserDataStore
+import io.github.aoguai.sesameag.util.UserDataStoreManager
 import io.github.aoguai.sesameag.util.maps.UserMap
 import java.util.concurrent.atomic.AtomicInteger
 import java.util.concurrent.atomic.AtomicLong
@@ -95,26 +96,22 @@ object EnergyWaitingPersistence {
     private val lastPersistedTaskCount = AtomicInteger(-1)
 
     /**
-     * 获取当前账号的 DataStore 存储键
-     * 每个账号使用独立的键，避免多账号切换时数据混淆
-     *
-     * @return 包含当前用户 uid 的存储键，如果 uid 为空则使用默认键
+     * 获取当前账号的 UserDataStore 实例
      */
-    private fun getDataStoreKey(): String {
+    private fun getStore(): UserDataStore? {
         val currentUid = AccountSessionCoordinator.currentUserId() ?: UserMap.currentUid
-        return if (currentUid.isNullOrEmpty()) {
-            "energy_waiting_tasks_default"
-        } else {
-            "energy_waiting_tasks_$currentUid"
-        }
+        return UserDataStoreManager.getInstance(currentUid)
     }
 
+    private fun getDataStoreKey(): String = "energy_waiting_tasks"
+
     /**
-     * 保存蹲点任务到 DataStore（异步）
+     * 保存蹲点任务到 UserDataStore（异步）
      *
      * @param tasks 当前活跃的蹲点任务
      */
     fun saveTasks(tasks: Map<String, EnergyWaitingManager.WaitingTask>) {
+        val store = getStore() ?: return
         val persistDataList = tasks.values.map { task ->
             WaitingTaskPersistData.fromWaitingTask(task)
         }
@@ -127,7 +124,7 @@ object EnergyWaitingPersistence {
                         return@withLock
                     }
 
-                    DataStore.put(dataStoreKey, persistDataList)
+                    store.put(dataStoreKey, persistDataList)
                     val currentCount = persistDataList.size
                     val previousCount = lastPersistedTaskCount.getAndSet(currentCount)
                     val statusText = when {
@@ -143,7 +140,7 @@ object EnergyWaitingPersistence {
                         else ->
                             "持久化同步：当前有效蹲点任务仍为${currentCount}个"
                     }
-                    Log.forest("$statusText (key: $dataStoreKey)")
+                    Log.forest("$statusText (uid: ${store.uid})")
                 }
             } catch (e: Exception) {
                 Log.printStackTrace(TAG, "保存蹲点任务失败:", e)
@@ -152,7 +149,7 @@ object EnergyWaitingPersistence {
     }
 
     /**
-     * 从 DataStore 加载蹲点任务
+     * 从 UserDataStore 加载蹲点任务
      *
      * @return 恢复的任务列表（已过滤过期任务）
      */
@@ -160,13 +157,14 @@ object EnergyWaitingPersistence {
         return try {
             val activeSession = AccountSessionCoordinator.currentSession()
                 ?: return emptyList()
+            val store = getStore() ?: return emptyList()
             val dataStoreKey = getDataStoreKey()
             val typeRef = object : TypeReference<List<WaitingTaskPersistData>>() {}
-            val persistDataList = DataStore.getOrCreate(dataStoreKey, typeRef)
+            val persistDataList = store.getOrCreate(dataStoreKey, typeRef)
 
             if (persistDataList.isEmpty()) {
                 lastPersistedTaskCount.set(0)
-                Log.forest("持久化存储中无蹲点任务 (key: $dataStoreKey)")
+                Log.forest("持久化存储中无蹲点任务 (uid: ${store.uid})")
                 return emptyList()
             }
 
@@ -217,11 +215,12 @@ object EnergyWaitingPersistence {
      * 清空持久化存储中的所有任务
      */
     fun clearTasks() {
+        val store = getStore() ?: return
         try {
             val dataStoreKey = getDataStoreKey()
-            DataStore.put(dataStoreKey, emptyList<WaitingTaskPersistData>())
+            store.put(dataStoreKey, emptyList<WaitingTaskPersistData>())
             lastPersistedTaskCount.set(0)
-            Log.forest("清空持久化存储 (key: $dataStoreKey)")
+            Log.forest("清空持久化存储 (uid: ${store.uid})")
         } catch (e: Exception) {
             Log.error(TAG, "清空持久化存储失败: ${e.message}")
         }

--- a/app/src/main/java/io/github/aoguai/sesameag/util/UserDataStore.kt
+++ b/app/src/main/java/io/github/aoguai/sesameag/util/UserDataStore.kt
@@ -1,0 +1,325 @@
+package io.github.aoguai.sesameag.util
+
+import android.annotation.SuppressLint
+import android.util.Log
+import com.fasterxml.jackson.core.type.TypeReference
+import com.fasterxml.jackson.core.util.DefaultIndenter
+import com.fasterxml.jackson.core.util.DefaultPrettyPrinter
+import com.fasterxml.jackson.databind.DeserializationFeature
+import com.fasterxml.jackson.databind.exc.MismatchedInputException
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.fasterxml.jackson.module.kotlin.readValue
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
+import java.io.File
+import java.nio.file.Path
+import java.nio.file.StandardWatchEventKinds
+import java.nio.file.WatchService
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.AtomicLong
+import java.util.concurrent.locks.ReentrantReadWriteLock
+import kotlin.concurrent.read
+import kotlin.concurrent.write
+import kotlin.math.abs
+
+/**
+ * 用户特异性数据存储类 (UserDataStore)
+ * 每个实例绑定一个特定的 UID，存储在对应的用户目录下。
+ */
+class UserDataStore(val uid: String, private val storageFile: File) {
+    private val tag = "UserDataStore-$uid"
+
+    companion object {
+        private val mapper = jacksonObjectMapper().apply {
+            configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+        }
+        private val prettyPrinter = DefaultPrettyPrinter().apply {
+            indentArraysWith(DefaultIndenter.SYSTEM_LINEFEED_INSTANCE)
+            indentObjectsWith(DefaultIndenter("    ", DefaultIndenter.SYS_LF))
+        }
+    }
+
+    private val data = ConcurrentHashMap<String, Any>()
+    private val lock = ReentrantReadWriteLock()
+
+    private val lastLoadedTime = AtomicLong(0)
+    private val lastWriteTime = AtomicLong(0)
+
+    @Volatile
+    private var watcherJob: Job? = null
+
+    @Volatile
+    private var watchService: WatchService? = null
+
+    private var onChangeListener: (() -> Unit)? = null
+
+    init {
+        ensureFileExists()
+        loadFromDisk()
+        startWatcherNio()
+    }
+
+    fun setOnChangeListener(listener: () -> Unit) {
+        onChangeListener = listener
+    }
+
+    private fun ensureFileExists() {
+        try {
+            val dir = storageFile.parentFile ?: return
+            if (!dir.exists()) {
+                dir.mkdirs()
+            }
+            setWorldReadableWritable(dir)
+
+            if (!storageFile.exists()) {
+                storageFile.createNewFile()
+                setWorldReadableWritable(storageFile)
+                storageFile.writeText("{}")
+            }
+        } catch (e: Exception) {
+            Log.e(tag, "Failed to ensure storage file exists", e)
+        }
+    }
+
+    @SuppressLint("SetWorldReadable", "SetWorldWritable")
+    private fun setWorldReadableWritable(file: File) {
+        try {
+            file.setReadable(true, false)
+            file.setWritable(true, false)
+            file.setExecutable(true, false)
+        } catch (_: Exception) {}
+    }
+
+    fun shutdown() {
+        watcherJob?.cancel()
+        watcherJob = null
+        try {
+            watchService?.close()
+        } catch (_: Throwable) {}
+        watchService = null
+        Log.i(tag, "Watcher stopped for user $uid")
+    }
+
+    inline fun <reified T : Any> getOrCreate(key: String): T {
+        return getOrCreate(key, object : TypeReference<T>() {})
+    }
+
+    fun <T> get(key: String, clazz: Class<T>): T? = lock.read {
+        try {
+            data[key]?.let { mapper.convertValue(it, clazz) }
+        } catch (e: Exception) {
+            Log.e(tag, "Error converting value for key: $key", e)
+            null
+        }
+    }
+
+    fun <T : Any> getOrCreate(key: String, typeRef: TypeReference<T>): T = lock.write {
+        forceLoadFromDisk()
+        data[key]?.let {
+            try {
+                return mapper.convertValue(it, typeRef)
+            } catch (e: Exception) {
+                Log.w(tag, "Data mismatch for key $key, overwriting with default.", e)
+            }
+        }
+
+        val default: T = createDefault(typeRef)
+        data[key] = default
+        saveToDisk()
+        default
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    private fun <T> createDefault(typeRef: TypeReference<T>): T {
+        val javaType = mapper.typeFactory.constructType(typeRef)
+        val rawClass = javaType.rawClass
+        return when {
+            List::class.java.isAssignableFrom(rawClass) -> ArrayList<Any>() as T
+            Set::class.java.isAssignableFrom(rawClass) -> LinkedHashSet<Any>() as T
+            Map::class.java.isAssignableFrom(rawClass) -> LinkedHashMap<String, Any>() as T
+            rawClass == String::class.java -> "" as T
+            rawClass == Boolean::class.java || rawClass == Boolean::class.javaObjectType -> false as T
+            rawClass == Int::class.java || rawClass == Int::class.javaObjectType -> 0 as T
+            rawClass == Long::class.java || rawClass == Long::class.javaObjectType -> 0L as T
+            else -> {
+                try {
+                    rawClass.getDeclaredConstructor().newInstance() as T
+                } catch (e: Exception) {
+                    throw RuntimeException("Could not create default value for ${rawClass.name}", e)
+                }
+            }
+        }
+    }
+
+    private fun forceLoadFromDisk() {
+        try {
+            if (!storageFile.exists() || storageFile.length() == 0L) {
+                data.clear()
+                lastLoadedTime.set(0)
+                return
+            }
+            val currentModTime = storageFile.lastModified()
+            if (currentModTime <= lastLoadedTime.get()) return
+
+            val loaded: Map<String, Any> = mapper.readValue(storageFile)
+            data.clear()
+            data.putAll(loaded)
+            lastLoadedTime.set(currentModTime)
+        } catch (e: Exception) {
+            if (e !is MismatchedInputException) {
+                Log.w(tag, "Force load from disk failed: ${e.message}")
+            }
+        }
+    }
+
+    private fun loadFromDisk() {
+        if (!storageFile.exists()) return
+        val currentModTime = storageFile.lastModified()
+        if (currentModTime <= lastLoadedTime.get()) return
+        if (abs(currentModTime - lastWriteTime.get()) < 500) {
+            lastLoadedTime.set(currentModTime)
+            return
+        }
+
+        lock.write {
+            try {
+                if (storageFile.length() == 0L) return@write
+                val loaded: Map<String, Any> = mapper.readValue(storageFile)
+                data.clear()
+                data.putAll(loaded)
+                lastLoadedTime.set(currentModTime)
+                onChangeListener?.invoke()
+            } catch (e: Exception) {
+                if (e !is MismatchedInputException) {
+                    Log.w(tag, "Failed to load: ${e.message}")
+                }
+            }
+        }
+    }
+
+    private fun saveToDisk() {
+        try {
+            val tempFile = File(storageFile.parentFile, storageFile.name + ".tmp")
+            mapper.writer(prettyPrinter).writeValue(tempFile, data)
+            setWorldReadableWritable(tempFile)
+            lastWriteTime.set(System.currentTimeMillis())
+            var renameSuccess = tempFile.renameTo(storageFile)
+            if (!renameSuccess) {
+                if (storageFile.exists()) storageFile.delete()
+                renameSuccess = tempFile.renameTo(storageFile)
+            }
+            if (!renameSuccess) {
+                tempFile.copyTo(storageFile, overwrite = true)
+                tempFile.delete()
+            }
+            setWorldReadableWritable(storageFile)
+            lastLoadedTime.set(storageFile.lastModified())
+        } catch (e: Exception) {
+            Log.e(tag, "Failed to save config", e)
+        }
+    }
+
+    private fun startWatcherNio() {
+        watcherJob?.cancel()
+        watcherJob = GlobalThreadPools.execute(Dispatchers.IO) {
+            val path = storageFile.toPath().parent ?: return@execute
+            val watch = runCatching {
+                watchService?.close()
+                path.fileSystem.newWatchService()
+            }.getOrNull() ?: return@execute
+
+            watchService = watch
+            runCatching {
+                path.register(watch, StandardWatchEventKinds.ENTRY_MODIFY)
+            }.onFailure { e ->
+                runCatching { watch.close() }
+                Log.e(tag, "Failed to register watch service", e)
+                return@execute
+            }
+
+            try {
+                while (isActive) {
+                    val key = try {
+                        watch.poll(1, TimeUnit.SECONDS) ?: continue
+                    } catch (_: Exception) { return@execute }
+
+                    var shouldReload = false
+                    key.pollEvents().forEach { event ->
+                        val changedPath = event.context() as? Path
+                        if (changedPath?.toString() == storageFile.name) {
+                            shouldReload = true
+                        }
+                    }
+                    if (shouldReload) {
+                        delay(100)
+                        loadFromDisk()
+                    }
+                    if (!key.reset()) return@execute
+                }
+            } catch (_: CancellationException) {
+            } catch (e: Exception) {
+                Log.e(tag, "File watcher died", e)
+            } finally {
+                runCatching { watch.close() }
+                if (watchService === watch) watchService = null
+            }
+        }
+    }
+
+    fun put(key: String, value: Any) = lock.write {
+        forceLoadFromDisk()
+        data[key] = value
+        saveToDisk()
+    }
+
+    fun remove(key: String) = lock.write {
+        forceLoadFromDisk()
+        data.remove(key)
+        saveToDisk()
+    }
+
+    /* --- 持续化标记 (Persistent Flags) 扩展 --- */
+
+    /**
+     * 设置一个持久化标记，直到指定的时间戳过期。
+     * @param flag 标记名
+     * @param expiryTimeMillis 过期时间戳（毫秒）。传入 -1 代表永久有效。
+     */
+    fun setPersistentFlag(flag: String, expiryTimeMillis: Long) {
+        lock.write {
+            val typeRef = object : TypeReference<MutableMap<String, Long>>() {}
+            val flags = getOrCreate("persistent_flags", typeRef).toMutableMap()
+            flags[flag] = expiryTimeMillis
+            put("persistent_flags", flags)
+        }
+    }
+
+    /**
+     * 检查持久化标记是否有效（未过期）。
+     */
+    fun hasPersistentFlag(flag: String): Boolean {
+        lock.read {
+            val flags = data["persistent_flags"] as? Map<*, *> ?: return false
+            val expiry = (flags[flag] as? Number)?.toLong() ?: return false
+            if (expiry == -1L) return true
+            return System.currentTimeMillis() < expiry
+        }
+    }
+
+    /**
+     * 移除持久化标记。
+     */
+    fun removePersistentFlag(flag: String) {
+        lock.write {
+            val typeRef = object : TypeReference<MutableMap<String, Long>>() {}
+            val flags = getOrCreate("persistent_flags", typeRef).toMutableMap()
+            if (flags.remove(flag) != null) {
+                put("persistent_flags", flags)
+            }
+        }
+    }
+}

--- a/app/src/main/java/io/github/aoguai/sesameag/util/UserDataStoreManager.kt
+++ b/app/src/main/java/io/github/aoguai/sesameag/util/UserDataStoreManager.kt
@@ -1,0 +1,70 @@
+package io.github.aoguai.sesameag.util
+
+import io.github.aoguai.sesameag.util.maps.UserMap
+import java.util.concurrent.ConcurrentHashMap
+
+/**
+ * UserDataStore 管理器
+ * 负责维护各账号 UserDataStore 实例的生命周期，确保路径隔离与按需加载。
+ */
+object UserDataStoreManager {
+    private val stores = ConcurrentHashMap<String, UserDataStore>()
+
+    /**
+     * 获取指定 UID 的 UserDataStore 实例。
+     * 采用“独占式”管理策略：仅为真实有效 UID 创建实例，且切换时自动释放。
+     */
+    @JvmStatic
+    @Synchronized
+    fun getInstance(uid: String?): UserDataStore? {
+        // 过滤无效或占位 UID
+        if (uid.isNullOrEmpty() || uid == "default") return null
+        
+        // 自动清理逻辑：如果当前缓存了其他真实 UID，则在切换时自动释放
+        val it = stores.iterator()
+        while (it.hasNext()) {
+            val entry = it.next()
+            if (entry.key != uid) {
+                entry.value.shutdown()
+                it.remove()
+            }
+        }
+
+        return stores.getOrPut(uid) {
+            val userDir = Files.getUserConfigDir(uid)
+            val file = java.io.File(userDir, "UserDataStore.json")
+            UserDataStore(uid, file)
+        }
+    }
+
+    /**
+     * 获取当前账号的 UserDataStore 实例。
+     */
+    @JvmStatic
+    fun getCurrentInstance(): UserDataStore? {
+        return getInstance(UserMap.currentUid)
+    }
+
+    /**
+     * 释放特定用户的 DataStore 实例。
+     */
+    @JvmStatic
+    @Synchronized
+    fun releaseInstance(uid: String?) {
+        if (uid.isNullOrEmpty()) return
+        stores.remove(uid)?.shutdown()
+    }
+
+    /**
+     * 关机/重启时释放所有实例。
+     */
+    @JvmStatic
+    @Synchronized
+    fun shutdownAll() {
+        val it = stores.values.iterator()
+        while (it.hasNext()) {
+            it.next().shutdown()
+            it.remove()
+        }
+    }
+}


### PR DESCRIPTION
- 森林蹲点迁移到UserDataStore.kt中作为示例。
- 目前DataStore存储了大量和特定用户相关的数据，这些数据应该单独存储到用户独立文件夹中，使特定用户可以读取自己的数据即可，全部放在DataStore导致该文件膨胀，读写压力大并且没有必要
- 将用户相关的蹲点等等数据写入到UserDataStore.json中，使可以只读取自己的数据，避免读取其他用户数据，
- 你把庄园蹲点存入了PersistentScheduleRegistry然后保存在DataStore，可以考虑迁移出来放到UserDataStore中。项目中仍有其他用户数据也可以迁移出来
- 同时UserDataStore提供了类似Status中的flag方法，针对捐蛋排位赛到达最高段位领取奖励后可以设置flag使在赛季结束前不再执行该方法。（已适配）