### PR TITLE
fix: unify NavDisplay rendering path to fix crash on back from logs page

### DIFF
--- a/app/src/main/java/io/github/aoguai/sesameag/ui/screen/MainScreen.kt
+++ b/app/src/main/java/io/github/aoguai/sesameag/ui/screen/MainScreen.kt
@@ -378,17 +378,11 @@ fun MainScreen(
             }
         },
     ) { modifier ->
-        if (isTopLevelRoute) {
-            Box(modifier.fillMaxSize()) {
-                selectedEntries.last().Content()
-            }
-        } else {
-            NavDisplay(
-                entries = selectedEntries,
-                modifier = modifier.fillMaxSize(),
-                onBack = { currentStack.removeLastOrNull() },
-            )
-        }
+        NavDisplay(
+            entries = selectedEntries,
+            modifier = modifier.fillMaxSize(),
+            onBack = { currentStack.removeLastOrNull() },
+        )
     }
 
     CommonAlertDialog(

--- a/app/src/main/java/io/github/aoguai/sesameag/ui/screen/MainScreen.kt
+++ b/app/src/main/java/io/github/aoguai/sesameag/ui/screen/MainScreen.kt
@@ -28,6 +28,7 @@ import androidx.compose.material3.adaptive.navigationsuite.NavigationSuiteScaffo
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.key
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
@@ -378,11 +379,13 @@ fun MainScreen(
             }
         },
     ) { modifier ->
-        NavDisplay(
-            entries = selectedEntries,
-            modifier = modifier.fillMaxSize(),
-            onBack = { currentStack.removeLastOrNull() },
-        )
+        key(selected) {
+            NavDisplay(
+                entries = selectedEntries,
+                modifier = modifier.fillMaxSize(),
+                onBack = { currentStack.removeLastOrNull() },
+            )
+        }
     }
 
     CommonAlertDialog(


### PR DESCRIPTION
## 问题

在小米澎湃 OS 3 上从日志页返回时应用闪退，堆栈为：

```
java.lang.IllegalArgumentException: Key Logs was used multiple times
```

## 根因

MainScreen 存在双渲染路径：

- 顶层 tab 根页面：`Box { selectedEntries.last().Content() }`
- 子页面：`NavDisplay`

两条路径共用同一个 `SaveableStateHolder`（来自 `rememberSaveableStateHolderNavEntryDecorator`）。从日志页 pop 返回时，预测性返回动画中 NavDisplay 已组合 `Logs` 场景（注册 key `Logs`），同一重组帧里顶层 Box 又挂载 `SaveableStateProvider("Logs")`，同一 holder 内 key 重复触发 `IllegalArgumentException`。

## 修复

统一走 `NavDisplay` 单渲染路径，保证每个 entry 的 `SaveableStateProvider` 任何时刻只有一处存活。这是 Navigation3 官方推荐模式。

副作用：切换 tab 时会有过渡动画（原先瞬时切换）。
